### PR TITLE
Add "Why A2" landing page — drag-and-drop theme section (+ HTML page fallback)

### DIFF
--- a/theme/sections/why-a2.liquid
+++ b/theme/sections/why-a2.liquid
@@ -484,7 +484,7 @@
     { "type": "text", "id": "cap_eyebrow", "label": "Eyebrow", "default": "Free sizing guide" },
     { "type": "text", "id": "cap_heading", "label": "Heading", "default": "Sizing a triathlon bike is harder than it should be." },
     { "type": "textarea", "id": "cap_sub", "label": "Subhead", "default": "Get our free guide and we'll help you dial in the right frame size, fit, and setup — before you ever click \"buy.\"" },
-    { "type": "text", "id": "klaviyo_form_id", "label": "Klaviyo form ID (e.g. Wq8aBc). Leave blank to show the placeholder form." },
+    { "type": "text", "id": "klaviyo_form_id", "label": "Klaviyo form ID (e.g. Wq8aBc) — blank shows placeholder" },
     { "type": "text", "id": "cap_trust", "label": "Trust line", "default": "No spam. Unsubscribe anytime." }
   ],
   "presets": [

--- a/theme/sections/why-a2.liquid
+++ b/theme/sections/why-a2.liquid
@@ -1,0 +1,494 @@
+{% comment %}
+  "Why A2" landing page section for A2 Bikes.
+  All copy + every image is editable in the theme editor (Customize).
+  Drop this section onto the "why-a2" page template (templates/page.why-a2.json).
+{% endcomment %}
+
+{% raw %}
+<style>
+.whya2{
+  --ink:#0E0F11; --ink-2:#17191C; --carbon:#24272B;
+  --paper:#FFFFFF; --paper-2:#F4F3EF; --line:#E2DFD8;
+  --muted:#6A6F75; --muted-dk:#A7ABB0;
+  --accent:#E5322B; --accent-deep:#C32219; --on-accent:#FFFFFF;
+  --maxw:1240px; --gutter:clamp(20px,5vw,64px);
+  --shadow:0 1px 2px rgba(16,17,19,.05), 0 18px 40px -24px rgba(16,17,19,.28);
+  margin-left:calc(50% - 50vw);
+  margin-right:calc(50% - 50vw);
+  overflow-x:hidden;
+  font-family:'Instrument Sans',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  color:var(--ink);
+  line-height:1.5;
+  text-align:left;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+}
+.whya2 *{ box-sizing:border-box; }
+.whya2 h1,.whya2 h2,.whya2 h3,.whya2 p,.whya2 ul,.whya2 figure,.whya2 blockquote{ margin:0; }
+.whya2 a{ color:inherit; text-decoration:none; }
+.whya2 ul{ list-style:none; padding:0; }
+.whya2 img{ max-width:100%; display:block; }
+
+.wa-wrap{ width:100%; max-width:var(--maxw); margin:0 auto; padding-left:var(--gutter); padding-right:var(--gutter); }
+.wa-sec{ padding:clamp(72px,9vw,128px) 0; }
+.wa-sec--paper{ background:var(--paper); }
+.wa-sec--paper2{ background:var(--paper-2); }
+.wa-sec--dark{ background:var(--ink); color:#fff; position:relative; }
+
+.wa-eyebrow{ text-transform:uppercase; font-weight:600; letter-spacing:.22em; font-size:.78rem; color:var(--accent); }
+.wa-sec--dark .wa-eyebrow{ color:#fff; }
+
+.wa-display{ font-size:clamp(2.5rem,6.4vw,5.4rem); font-weight:700; line-height:.98; letter-spacing:-.03em; }
+.wa-h2{ font-size:clamp(1.9rem,3.6vw,3rem); font-weight:700; line-height:1.04; letter-spacing:-.02em; }
+.wa-lede{ font-size:clamp(1.05rem,1.6vw,1.25rem); color:var(--muted); max-width:640px; }
+.wa-sec--dark .wa-lede{ color:var(--muted-dk); }
+.wa-head{ max-width:760px; }
+.wa-head .wa-h2{ margin-top:14px; }
+.wa-head .wa-lede{ margin-top:18px; }
+
+.wa-btn{ display:inline-flex; align-items:center; justify-content:center; gap:.5em;
+  font:inherit; font-weight:600; font-size:1rem; line-height:1; cursor:pointer;
+  padding:.95em 1.5em; min-height:48px; border-radius:4px; border:1px solid transparent;
+  transition:transform .18s ease, background .18s ease, border-color .18s ease; }
+.wa-btn--primary{ background:var(--accent); color:var(--on-accent); }
+.wa-btn--primary:hover{ background:var(--accent-deep); transform:translateY(-2px); }
+.wa-btn--ghost-light{ background:transparent; color:#fff; border-color:rgba(255,255,255,.45); }
+.wa-btn--ghost-light:hover{ border-color:#fff; transform:translateY(-2px); }
+
+.wa-ph{ position:relative; background:linear-gradient(135deg,#1b1d20,#0e0f11); }
+.wa-ph::after{ content:attr(data-label); position:absolute; inset:0; display:flex;
+  align-items:center; justify-content:center; text-align:center; padding:1rem;
+  font-size:.72rem; letter-spacing:.18em; text-transform:uppercase; color:rgba(255,255,255,.34); }
+.wa-ph--light{ background:linear-gradient(135deg,#ECEAE4,#F4F3EF); }
+.wa-ph--light::after{ color:rgba(20,22,24,.32); }
+
+.whya2.wa-anim .reveal{ opacity:0; transform:translateY(26px);
+  transition:opacity .7s cubic-bezier(.16,.84,.44,1), transform .7s cubic-bezier(.16,.84,.44,1); }
+.whya2.wa-anim .reveal.is-in{ opacity:1; transform:none; }
+.whya2.wa-anim .reveal.d1{ transition-delay:.08s; }
+.whya2.wa-anim .reveal.d2{ transition-delay:.16s; }
+.whya2.wa-anim .reveal.d3{ transition-delay:.24s; }
+@media (prefers-reduced-motion:reduce){
+  .whya2.wa-anim .reveal{ opacity:1 !important; transform:none !important; transition:none !important; }
+}
+
+.wa-hero{ position:relative; min-height:100svh; display:flex; align-items:flex-end; background:var(--ink); }
+.wa-hero-img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0; }
+.wa-hero-scrim{ position:absolute; inset:0; z-index:1;
+  background:
+    linear-gradient(90deg, rgba(14,15,17,.78), rgba(14,15,17,.12) 62%),
+    linear-gradient(0deg, rgba(14,15,17,.94), rgba(14,15,17,.10) 62%); }
+.wa-hero-inner{ position:relative; z-index:2; padding-top:140px; padding-bottom:clamp(72px,12vh,140px); }
+.wa-hero-inner .wa-display{ max-width:760px; color:#fff; margin-top:18px; }
+.wa-hero-sub{ max-width:620px; margin-top:22px; font-size:clamp(1.05rem,1.7vw,1.4rem); color:rgba(255,255,255,.84); }
+.wa-hero-sub b{ color:#fff; font-weight:700; }
+.wa-hero-cta{ display:flex; flex-wrap:wrap; gap:14px; margin-top:34px; }
+.wa-scrollcue{ position:absolute; left:50%; bottom:22px; transform:translateX(-50%); z-index:2;
+  font-size:.72rem; letter-spacing:.24em; text-transform:uppercase; color:rgba(255,255,255,.7);
+  display:flex; flex-direction:column; align-items:center; gap:8px; }
+.wa-scrollcue::after{ content:""; width:1px; height:34px; background:rgba(255,255,255,.55); animation:wa-cue 1.8s ease-in-out infinite; transform-origin:top; }
+@keyframes wa-cue{ 0%{ transform:scaleY(0); } 40%{ transform:scaleY(1); } 100%{ transform:scaleY(0); } }
+@media (max-width:600px){ .wa-scrollcue{ display:none; } }
+@media (prefers-reduced-motion:reduce){ .wa-scrollcue::after{ animation:none; } }
+
+.wa-cred{ position:relative; }
+.wa-cred-bg{ position:absolute; inset:0; z-index:0; background-size:cover; background-position:center; }
+.wa-cred-scrim{ position:absolute; inset:0; z-index:1; background:linear-gradient(0deg, rgba(14,15,17,.92), rgba(14,15,17,.74)); }
+.wa-cred .wa-wrap{ position:relative; z-index:2; }
+.wa-proof{ display:grid; grid-template-columns:repeat(3,1fr); gap:clamp(28px,4vw,56px); margin-top:clamp(40px,6vw,72px); }
+.wa-proof-item{ padding-top:22px; border-top:2px solid rgba(255,255,255,.16); }
+.wa-proof-num{ font-weight:700; font-size:1rem; color:var(--accent); letter-spacing:.04em; }
+.wa-proof-item h3{ font-size:clamp(1.2rem,1.8vw,1.45rem); font-weight:700; line-height:1.18; margin-top:14px; letter-spacing:-.01em; }
+.wa-proof-item p{ color:var(--muted-dk); margin-top:12px; font-size:1rem; }
+.wa-stars{ color:var(--accent); letter-spacing:.12em; margin-top:14px; font-size:1.05rem; }
+@media (max-width:760px){ .wa-proof{ grid-template-columns:1fr; } }
+
+.wa-cards3{ display:grid; grid-template-columns:repeat(3,1fr); gap:24px; margin-top:clamp(40px,5vw,64px); }
+.wa-card{ background:var(--paper); border:1px solid var(--line); border-radius:14px; padding:30px;
+  display:flex; flex-direction:column; min-height:300px;
+  transition:transform .22s ease, box-shadow .22s ease; }
+.wa-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-card-head{ font-size:clamp(1.5rem,2.2vw,1.9rem); font-weight:700; letter-spacing:-.02em; line-height:1.08; color:var(--ink); }
+.wa-card-head s{ color:var(--accent); text-decoration-thickness:2px; }
+.wa-card h3{ font-size:1.12rem; font-weight:700; margin-top:18px; color:var(--ink); }
+.wa-card p{ color:var(--muted); margin-top:10px; font-size:1rem; }
+.wa-tag{ margin-top:auto; padding-top:22px; text-transform:uppercase; letter-spacing:.16em; font-size:.72rem; font-weight:600; color:var(--accent); }
+@media (max-width:860px){ .wa-cards3{ grid-template-columns:1fr; } }
+
+.wa-prod{ display:grid; grid-template-columns:repeat(2,1fr); gap:28px; margin-top:clamp(40px,5vw,64px); }
+.wa-prod-card{ display:flex; flex-direction:column; background:var(--paper); border:1px solid var(--line);
+  border-radius:14px; overflow:hidden; transition:transform .22s ease, box-shadow .22s ease; }
+.wa-prod-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-prod-mediawrap{ overflow:hidden; }
+.wa-prod-media{ position:relative; aspect-ratio:16/11; background-size:cover; background-position:center;
+  transition:transform .4s ease; }
+.wa-prod-card:hover .wa-prod-media{ transform:scale(1.04); }
+.wa-badge{ position:absolute; top:14px; left:14px; z-index:2; background:rgba(14,15,17,.7); color:#fff;
+  text-transform:uppercase; letter-spacing:.14em; font-size:.66rem; font-weight:600; padding:7px 11px; border-radius:3px; }
+.wa-prod-body{ padding:26px 28px 30px; }
+.wa-prod-row{ display:flex; align-items:baseline; justify-content:space-between; gap:14px; }
+.wa-prod-row h3{ font-size:clamp(1.5rem,2.4vw,2.1rem); font-weight:700; letter-spacing:-.02em; color:var(--ink); }
+.wa-price{ color:var(--muted); font-size:1rem; white-space:nowrap; }
+.wa-price b{ color:var(--ink); font-weight:700; }
+.wa-prod-body p{ color:var(--muted); margin-top:12px; }
+.wa-arrow{ display:inline-flex; align-items:center; gap:.4em; color:var(--accent); font-weight:600; margin-top:18px; }
+.wa-arrow span{ transition:transform .2s ease; }
+.wa-prod-card:hover .wa-arrow span{ transform:translateX(4px); }
+@media (max-width:820px){ .wa-prod{ grid-template-columns:1fr; } }
+
+.wa-ath{ display:grid; grid-template-columns:repeat(3,1fr); gap:24px; margin-top:clamp(40px,5vw,64px); }
+.wa-ath-card{ background:var(--paper); border:1px solid var(--line); border-radius:14px; overflow:hidden;
+  display:flex; flex-direction:column; transition:transform .22s ease, box-shadow .22s ease; }
+.wa-ath-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-ath-photo{ aspect-ratio:4/3; background-size:cover; background-position:center; }
+.wa-ath-body{ padding:26px 26px 28px; display:flex; flex-direction:column; flex:1; }
+.wa-ath-body blockquote{ position:relative; padding-top:22px; color:var(--ink); font-size:1.08rem; line-height:1.45; }
+.wa-ath-body blockquote::before{ content:""; position:absolute; top:0; left:0; width:30px; height:3px; background:var(--accent); }
+.wa-ath-name{ font-weight:700; margin-top:20px; color:var(--ink); }
+.wa-ath-race{ color:var(--muted); font-size:.95rem; margin-top:4px; }
+@media (max-width:860px){
+  .wa-ath{ grid-template-columns:1fr; }
+  .wa-ath-card{ max-width:460px; margin:0 auto; width:100%; }
+}
+
+.wa-capture{ position:relative; overflow:hidden; }
+.wa-capture::before{ content:""; position:absolute; top:-30%; right:-10%; width:60%; height:120%; z-index:0;
+  background:radial-gradient(closest-side, rgba(229,50,43,.4), rgba(229,50,43,0) 70%); pointer-events:none; }
+.wa-capture .wa-wrap{ position:relative; z-index:1; }
+.wa-capture-inner{ max-width:720px; margin:0 auto; text-align:center; }
+.wa-capture-inner .wa-h2{ margin-top:14px; }
+.wa-capture-inner .wa-lede{ margin:18px auto 0; color:var(--muted-dk); }
+.wa-form{ display:flex; gap:12px; margin:30px auto 0; max-width:520px; }
+.wa-form input[type=email]{ flex:1; min-width:0; font:inherit; font-size:1rem; padding:.95em 1.1em; min-height:48px;
+  border-radius:4px; border:1px solid rgba(255,255,255,.22); background:rgba(255,255,255,.06); color:#fff; }
+.wa-form input[type=email]::placeholder{ color:rgba(255,255,255,.55); }
+.wa-form input[type=email]:focus{ outline:none; border-color:var(--accent); }
+.wa-trust{ margin-top:16px; font-size:.85rem; color:var(--muted-dk); }
+.wa-hint{ margin-top:16px; font-size:.8rem; color:#ffd2cf; }
+.wa-form-success{ display:none; margin:30px auto 0; max-width:520px; padding:20px; border-radius:8px;
+  border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.05); color:#fff; font-weight:600; }
+@media (max-width:520px){ .wa-form{ flex-direction:column; } }
+</style>
+{% endraw %}
+
+
+<div class="whya2">
+
+  {%- comment -%} 1 · HERO {%- endcomment -%}
+  <section class="wa-hero wa-sec--dark">
+    {%- if section.settings.hero_image -%}
+      {{ section.settings.hero_image | image_url: width: 2400 | image_tag: class: 'wa-hero-img', loading: 'eager', fetchpriority: 'high', widths: '600,900,1200,1600,2000,2400', sizes: '100vw', alt: section.settings.hero_image.alt }}
+    {%- else -%}
+      <div class="wa-hero-img wa-ph" data-label="Hero image — set in theme editor (use an action/riding shot)"></div>
+    {%- endif -%}
+    <div class="wa-hero-scrim"></div>
+    <div class="wa-wrap wa-hero-inner">
+      <p class="wa-eyebrow reveal">{{ section.settings.hero_eyebrow }}</p>
+      <h1 class="wa-display reveal d1">{{ section.settings.hero_heading }}</h1>
+      <p class="wa-hero-sub reveal d2">{{ section.settings.hero_sub }}</p>
+      <div class="wa-hero-cta reveal d3">
+        <a class="wa-btn wa-btn--primary" href="{{ section.settings.hero_cta1_link | default: '/collections/sp' }}">{{ section.settings.hero_cta1_label }} →</a>
+        <a class="wa-btn wa-btn--ghost-light" href="#wa-capture">{{ section.settings.hero_cta2_label }}</a>
+      </div>
+    </div>
+    <div class="wa-scrollcue" aria-hidden="true">Scroll</div>
+  </section>
+
+  {%- comment -%} 2 · CREDIBILITY {%- endcomment -%}
+  <section class="wa-sec wa-sec--dark wa-cred">
+    <div class="wa-cred-bg{% unless section.settings.cred_image %} wa-ph{% endunless %}"{% if section.settings.cred_image %} style="background-image:url({{ section.settings.cred_image | image_url: width: 2000 }})"{% else %} data-label="Race photo — set in theme editor"{% endif %}></div>
+    <div class="wa-cred-scrim"></div>
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">{{ section.settings.cred_eyebrow }}</p>
+        <h2 class="wa-h2">{{ section.settings.cred_heading }}</h2>
+      </div>
+      <div class="wa-proof">
+        <div class="wa-proof-item reveal d1">
+          <div class="wa-proof-num">01</div>
+          <h3>{{ section.settings.proof1_title }}</h3>
+          <p>{{ section.settings.proof1_body }}</p>
+        </div>
+        <div class="wa-proof-item reveal d2">
+          <div class="wa-proof-num">02</div>
+          <h3>{{ section.settings.proof2_title }}</h3>
+          <p>{{ section.settings.proof2_body }}</p>
+        </div>
+        <div class="wa-proof-item reveal d3">
+          <div class="wa-proof-num">03</div>
+          <h3>{{ section.settings.proof3_title }}</h3>
+          <div class="wa-stars" aria-label="5 out of 5 stars">★★★★★</div>
+          <p>{{ section.settings.proof3_body }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {%- comment -%} 3 · THE PROMISE {%- endcomment -%}
+  <section class="wa-sec wa-sec--paper2">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">{{ section.settings.promise_eyebrow }}</p>
+        <h2 class="wa-h2">{{ section.settings.promise_heading }}</h2>
+        <p class="wa-lede">{{ section.settings.promise_lede }}</p>
+      </div>
+      <div class="wa-cards3">
+        <article class="wa-card reveal d1">
+          <div class="wa-card-head"><s>No</s> {{ section.settings.card1_phrase }}</div>
+          <h3>{{ section.settings.card1_title }}</h3>
+          <p>{{ section.settings.card1_body }}</p>
+          <div class="wa-tag">{{ section.settings.card1_tag }}</div>
+        </article>
+        <article class="wa-card reveal d2">
+          <div class="wa-card-head"><s>No</s> {{ section.settings.card2_phrase }}</div>
+          <h3>{{ section.settings.card2_title }}</h3>
+          <p>{{ section.settings.card2_body }}</p>
+          <div class="wa-tag">{{ section.settings.card2_tag }}</div>
+        </article>
+        <article class="wa-card reveal d3">
+          <div class="wa-card-head"><s>No</s> {{ section.settings.card3_phrase }}</div>
+          <h3>{{ section.settings.card3_title }}</h3>
+          <p>{{ section.settings.card3_body }}</p>
+          <div class="wa-tag">{{ section.settings.card3_tag }}</div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  {%- comment -%} 4 · PRODUCT RANGE {%- endcomment -%}
+  <section class="wa-sec wa-sec--paper">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">{{ section.settings.prod_eyebrow }}</p>
+        <h2 class="wa-h2">{{ section.settings.prod_heading }}</h2>
+        <p class="wa-lede">{{ section.settings.prod_lede }}</p>
+      </div>
+      <div class="wa-prod">
+        <a class="wa-prod-card reveal d1" href="{{ section.settings.sp_link | default: '/pages/sp' }}">
+          <div class="wa-prod-mediawrap">
+            <div class="wa-prod-media{% unless section.settings.sp_image %} wa-ph wa-ph--light{% endunless %}"{% if section.settings.sp_image %} style="background-image:url({{ section.settings.sp_image | image_url: width: 1600 }})"{% else %} data-label="SP photo — set in theme editor"{% endif %}>
+              <span class="wa-badge">{{ section.settings.sp_badge }}</span>
+            </div>
+          </div>
+          <div class="wa-prod-body">
+            <div class="wa-prod-row">
+              <h3>{{ section.settings.sp_name }}</h3>
+              <div class="wa-price">from <b>{{ section.settings.sp_price }}</b></div>
+            </div>
+            <p>{{ section.settings.sp_body }}</p>
+            <div class="wa-arrow">Explore the {{ section.settings.sp_name }} <span>→</span></div>
+          </div>
+        </a>
+        <a class="wa-prod-card reveal d2" href="{{ section.settings.rogue_link | default: '/pages/rogue' }}">
+          <div class="wa-prod-mediawrap">
+            <div class="wa-prod-media{% unless section.settings.rogue_image %} wa-ph wa-ph--light{% endunless %}"{% if section.settings.rogue_image %} style="background-image:url({{ section.settings.rogue_image | image_url: width: 1600 }})"{% else %} data-label="Rogue photo — set in theme editor"{% endif %}>
+              <span class="wa-badge">{{ section.settings.rogue_badge }}</span>
+            </div>
+          </div>
+          <div class="wa-prod-body">
+            <div class="wa-prod-row">
+              <h3>{{ section.settings.rogue_name }}</h3>
+              <div class="wa-price">from <b>{{ section.settings.rogue_price }}</b></div>
+            </div>
+            <p>{{ section.settings.rogue_body }}</p>
+            <div class="wa-arrow">Explore the {{ section.settings.rogue_name }} <span>→</span></div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  {%- comment -%} 5 · ATHLETE PROOF {%- endcomment -%}
+  <section class="wa-sec wa-sec--paper2">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">{{ section.settings.ath_eyebrow }}</p>
+        <h2 class="wa-h2">{{ section.settings.ath_heading }}</h2>
+      </div>
+      <div class="wa-ath">
+        <article class="wa-ath-card reveal d1">
+          <div class="wa-ath-photo{% unless section.settings.ath1_image %} wa-ph wa-ph--light{% endunless %}"{% if section.settings.ath1_image %} style="background-image:url({{ section.settings.ath1_image | image_url: width: 900 }})"{% else %} data-label="Athlete photo — set in theme editor"{% endif %}></div>
+          <div class="wa-ath-body">
+            <blockquote>{{ section.settings.ath1_quote }}</blockquote>
+            <div class="wa-ath-name">{{ section.settings.ath1_name }}</div>
+            <div class="wa-ath-race">{{ section.settings.ath1_race }}</div>
+          </div>
+        </article>
+        <article class="wa-ath-card reveal d2">
+          <div class="wa-ath-photo{% unless section.settings.ath2_image %} wa-ph wa-ph--light{% endunless %}"{% if section.settings.ath2_image %} style="background-image:url({{ section.settings.ath2_image | image_url: width: 900 }})"{% else %} data-label="Athlete photo — set in theme editor"{% endif %}></div>
+          <div class="wa-ath-body">
+            <blockquote>{{ section.settings.ath2_quote }}</blockquote>
+            <div class="wa-ath-name">{{ section.settings.ath2_name }}</div>
+            <div class="wa-ath-race">{{ section.settings.ath2_race }}</div>
+          </div>
+        </article>
+        <article class="wa-ath-card reveal d3">
+          <div class="wa-ath-photo{% unless section.settings.ath3_image %} wa-ph wa-ph--light{% endunless %}"{% if section.settings.ath3_image %} style="background-image:url({{ section.settings.ath3_image | image_url: width: 900 }})"{% else %} data-label="Athlete photo — set in theme editor"{% endif %}></div>
+          <div class="wa-ath-body">
+            <blockquote>{{ section.settings.ath3_quote }}</blockquote>
+            <div class="wa-ath-name">{{ section.settings.ath3_name }}</div>
+            <div class="wa-ath-race">{{ section.settings.ath3_race }}</div>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  {%- comment -%} 6 · EMAIL CAPTURE {%- endcomment -%}
+  <section id="wa-capture" class="wa-sec wa-sec--dark wa-capture">
+    <div class="wa-wrap">
+      <div class="wa-capture-inner reveal">
+        <p class="wa-eyebrow">{{ section.settings.cap_eyebrow }}</p>
+        <h2 class="wa-h2">{{ section.settings.cap_heading }}</h2>
+        <p class="wa-lede">{{ section.settings.cap_sub }}</p>
+
+        {%- if section.settings.klaviyo_form_id != blank -%}
+          <div class="klaviyo-form-{{ section.settings.klaviyo_form_id }}"></div>
+        {%- else -%}
+          <form class="wa-form" novalidate>
+            <input type="email" name="email" placeholder="you@email.com" aria-label="Email address" required>
+            <button type="submit" class="wa-btn wa-btn--primary">Send me the guide</button>
+          </form>
+          <div class="wa-form-success">Check your inbox — your sizing guide is on the way. ✓</div>
+          {%- if request.design_mode -%}
+            <p class="wa-hint">Tip: paste your Klaviyo form ID into this section's settings to replace this placeholder form. Make sure the Klaviyo onsite script is loaded in theme.liquid.</p>
+          {%- endif -%}
+        {%- endif -%}
+
+        <p class="wa-trust">{{ section.settings.cap_trust }}</p>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+
+{% raw %}
+<script>
+(function () {
+  var root = document.querySelector('.whya2');
+  if (!root) return;
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!reduce) root.classList.add('wa-anim');
+  var items = root.querySelectorAll('.reveal');
+  function reveal() {
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    for (var i = 0; i < items.length; i++) {
+      var el = items[i];
+      if (el.classList.contains('is-in')) continue;
+      if (el.getBoundingClientRect().top < vh * 0.88) el.classList.add('is-in');
+    }
+  }
+  reveal();
+  window.addEventListener('scroll', reveal, { passive: true });
+  window.addEventListener('resize', reveal);
+  window.addEventListener('load', reveal);
+  var anchors = root.querySelectorAll('a[href^="#"]');
+  for (var a = 0; a < anchors.length; a++) {
+    anchors[a].addEventListener('click', function (e) {
+      var id = this.getAttribute('href');
+      if (id.length > 1) {
+        var target = document.querySelector(id);
+        if (target) { e.preventDefault(); target.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' }); }
+      }
+    });
+  }
+  var form = root.querySelector('.wa-form');
+  if (form) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var ok = root.querySelector('.wa-form-success');
+      if (ok) { form.style.display = 'none'; ok.style.display = 'block'; }
+    });
+  }
+})();
+</script>
+{% endraw %}
+
+{% schema %}
+{
+  "name": "Why A2",
+  "class": "why-a2-section",
+  "settings": [
+    { "type": "header", "content": "1 · Hero" },
+    { "type": "image_picker", "id": "hero_image", "label": "Hero image (use an action / riding shot, not a studio photo)" },
+    { "type": "text", "id": "hero_eyebrow", "label": "Eyebrow", "default": "Rider Focused. Always." },
+    { "type": "text", "id": "hero_heading", "label": "Heading", "default": "Pro-level triathlon bikes. Without the pro-level price." },
+    { "type": "inline_richtext", "id": "hero_sub", "label": "Subhead", "default": "The same design pedigree as a <b>Cervélo P-Series</b> — drawn by the engineer who shaped it — sold direct, so you skip the retail markup." },
+    { "type": "text", "id": "hero_cta1_label", "label": "Primary button label", "default": "See the bikes" },
+    { "type": "url", "id": "hero_cta1_link", "label": "Primary button link (defaults to /collections/sp)" },
+    { "type": "text", "id": "hero_cta2_label", "label": "Secondary button label (scrolls to the email form)", "default": "Get our sizing guide" },
+
+    { "type": "header", "content": "2 · Credibility" },
+    { "type": "image_picker", "id": "cred_image", "label": "Background race photo" },
+    { "type": "text", "id": "cred_eyebrow", "label": "Eyebrow", "default": "Proven, not promised" },
+    { "type": "text", "id": "cred_heading", "label": "Heading", "default": "Designed by Kevin Quan. Tested at Kona." },
+    { "type": "text", "id": "proof1_title", "label": "Proof 1 — title", "default": "Drawn by a former Cervélo P-Series engineer" },
+    { "type": "textarea", "id": "proof1_body", "label": "Proof 1 — body", "default": "A2's geometry comes from Kevin Quan — the engineer behind the Cervélo P-Series, one of the most successful triathlon bikes ever made." },
+    { "type": "text", "id": "proof2_title", "label": "Proof 2 — title", "default": "Trusted at the Ironman World Championships" },
+    { "type": "textarea", "id": "proof2_body", "label": "Proof 2 — body", "default": "A2 bikes have been raced on the lava fields of Kona — the toughest proving ground in the sport." },
+    { "type": "text", "id": "proof3_title", "label": "Proof 3 — title (shown with 5 stars)", "default": "Best Beginner Triathlon Bike" },
+    { "type": "textarea", "id": "proof3_body", "label": "Proof 3 — body", "default": "Named by Triathlete Magazine — a five-time winner of the category." },
+
+    { "type": "header", "content": "3 · The promise" },
+    { "type": "text", "id": "promise_eyebrow", "label": "Eyebrow", "default": "The A2 promise" },
+    { "type": "text", "id": "promise_heading", "label": "Heading", "default": "What you don't pay for" },
+    { "type": "textarea", "id": "promise_lede", "label": "Lede", "default": "A2 sells direct. That means your money goes into the bike — not the markup, the middleman, or next year's \"upgrade.\"" },
+    { "type": "text", "id": "card1_phrase", "label": "Card 1 — phrase after \"No\"", "default": "retail markup" },
+    { "type": "text", "id": "card1_title", "label": "Card 1 — title", "default": "Sold direct, priced honestly" },
+    { "type": "textarea", "id": "card1_body", "label": "Card 1 — body", "default": "Big brands build dealer margin and retail markup into the price. We don't. You pay for engineering and materials — nothing else." },
+    { "type": "text", "id": "card1_tag", "label": "Card 1 — tag", "default": "Direct-to-rider" },
+    { "type": "text", "id": "card2_phrase", "label": "Card 2 — phrase after \"No\"", "default": "dealer middleman" },
+    { "type": "text", "id": "card2_title", "label": "Card 2 — title", "default": "Ships from Oregon, set up at home" },
+    { "type": "textarea", "id": "card2_body", "label": "Card 2 — body", "default": "No showroom upsell. Your bike ships from our Oregon shop, ready to finish assembly at home with our step-by-step guides." },
+    { "type": "text", "id": "card2_tag", "label": "Card 2 — tag", "default": "Pacific Northwest built" },
+    { "type": "text", "id": "card3_phrase", "label": "Card 3 — phrase after \"No\"", "default": "annual obsolescence" },
+    { "type": "text", "id": "card3_title", "label": "Card 3 — title", "default": "Lifetime warranty, free size exchanges" },
+    { "type": "textarea", "id": "card3_body", "label": "Card 3 — body", "default": "We don't chase yearly model cycles. Your A2 is backed by a lifetime frame warranty and free size exchanges if the fit isn't right." },
+    { "type": "text", "id": "card3_tag", "label": "Card 3 — tag", "default": "Backed for life" },
+
+    { "type": "header", "content": "4 · Product range" },
+    { "type": "text", "id": "prod_eyebrow", "label": "Eyebrow", "default": "The lineup" },
+    { "type": "text", "id": "prod_heading", "label": "Heading", "default": "Find your A2" },
+    { "type": "textarea", "id": "prod_lede", "label": "Lede", "default": "Two platforms, one obsession: fast bikes that fit real riders — priced direct." },
+    { "type": "image_picker", "id": "sp_image", "label": "SP — image" },
+    { "type": "text", "id": "sp_badge", "label": "SP — badge", "default": "Triathlon" },
+    { "type": "text", "id": "sp_name", "label": "SP — name", "default": "SP" },
+    { "type": "text", "id": "sp_price", "label": "SP — price", "default": "$3,115" },
+    { "type": "textarea", "id": "sp_body", "label": "SP — description", "default": "Our triathlon and time-trial machine — superbike aerodynamics and fit, without the superbike price." },
+    { "type": "url", "id": "sp_link", "label": "SP — link (defaults to /pages/sp)" },
+    { "type": "image_picker", "id": "rogue_image", "label": "Rogue — image" },
+    { "type": "text", "id": "rogue_badge", "label": "Rogue — badge", "default": "Road & Gravel" },
+    { "type": "text", "id": "rogue_name", "label": "Rogue — name", "default": "Rogue" },
+    { "type": "text", "id": "rogue_price", "label": "Rogue — price", "default": "$2,699" },
+    { "type": "textarea", "id": "rogue_body", "label": "Rogue — description", "default": "One bike for road and gravel — fast on pavement, capable when the pavement ends." },
+    { "type": "url", "id": "rogue_link", "label": "Rogue — link (defaults to /pages/rogue)" },
+
+    { "type": "header", "content": "5 · Athlete proof" },
+    { "type": "text", "id": "ath_eyebrow", "label": "Eyebrow", "default": "Race proven" },
+    { "type": "text", "id": "ath_heading", "label": "Heading", "default": "Ridden by the A2 Racing Team" },
+    { "type": "image_picker", "id": "ath1_image", "label": "Athlete 1 — photo" },
+    { "type": "textarea", "id": "ath1_quote", "label": "Athlete 1 — quote", "default": "[Add Kinley's quote here]" },
+    { "type": "text", "id": "ath1_name", "label": "Athlete 1 — name", "default": "Kinley Bollinger" },
+    { "type": "text", "id": "ath1_race", "label": "Athlete 1 — race / achievement", "default": "1st Overall — Ironman 70.3 Puerto Rico · 4:40:39" },
+    { "type": "image_picker", "id": "ath2_image", "label": "Athlete 2 — photo" },
+    { "type": "textarea", "id": "ath2_quote", "label": "Athlete 2 — quote", "default": "[Athlete quote]" },
+    { "type": "text", "id": "ath2_name", "label": "Athlete 2 — name", "default": "[Athlete name]" },
+    { "type": "text", "id": "ath2_race", "label": "Athlete 2 — race / achievement", "default": "[Race / achievement]" },
+    { "type": "image_picker", "id": "ath3_image", "label": "Athlete 3 — photo" },
+    { "type": "textarea", "id": "ath3_quote", "label": "Athlete 3 — quote", "default": "[Athlete quote]" },
+    { "type": "text", "id": "ath3_name", "label": "Athlete 3 — name", "default": "[Athlete name]" },
+    { "type": "text", "id": "ath3_race", "label": "Athlete 3 — race / achievement", "default": "[Race / achievement]" },
+
+    { "type": "header", "content": "6 · Email capture (primary goal)" },
+    { "type": "text", "id": "cap_eyebrow", "label": "Eyebrow", "default": "Free sizing guide" },
+    { "type": "text", "id": "cap_heading", "label": "Heading", "default": "Sizing a triathlon bike is harder than it should be." },
+    { "type": "textarea", "id": "cap_sub", "label": "Subhead", "default": "Get our free guide and we'll help you dial in the right frame size, fit, and setup — before you ever click \"buy.\"" },
+    { "type": "text", "id": "klaviyo_form_id", "label": "Klaviyo form ID (e.g. Wq8aBc). Leave blank to show the placeholder form." },
+    { "type": "text", "id": "cap_trust", "label": "Trust line", "default": "No spam. Unsubscribe anytime." }
+  ],
+  "presets": [
+    { "name": "Why A2" }
+  ]
+}
+{% endschema %}

--- a/theme/templates/page.why-a2.json
+++ b/theme/templates/page.why-a2.json
@@ -1,0 +1,9 @@
+{
+  "sections": {
+    "main": {
+      "type": "why-a2",
+      "settings": {}
+    }
+  },
+  "order": ["main"]
+}

--- a/why-a2-shopify-page.html
+++ b/why-a2-shopify-page.html
@@ -1,0 +1,459 @@
+<!--
+============================================================================
+  A2 BIKES — "Why A2" landing page  (self-contained Shopify PAGE version)
+============================================================================
+  HOW TO USE
+  1. Shopify Admin → Online Store → Pages → Add page → title it "Why A2".
+  2. In the content editor click "< >" (Show HTML / code view).
+  3. Paste EVERYTHING in this file into that code view.
+  4. Save.  (Tip: after pasting in code view, click Save without toggling
+     back to the rich-text view — that view can strip <style>/<script>.)
+
+  THINGS TO SWAP BEFORE LAUNCH  (search for "REPLACE")
+  • Images  — the hero + SP card use real A2 CDN photos as stand-ins.
+              The hero MUST become an action/riding shot (not a studio shot).
+              Every image is a <div ... style="background-image:url(...)">;
+              just change the URL, or swap the labelled placeholders.
+  • Klaviyo — replace the visual <form> in section 6 with your Klaviyo embed:
+              <div class="klaviyo-form-XXXXXXX"></div>
+              and make sure the Klaviyo onsite script is loaded in theme.liquid.
+  • Athlete quotes — card 1 keeps Kinley's real result; add her real quote.
+              Cards 2 & 3 are placeholders for real A2 Racing Team athletes.
+  • Font  — this loads Instrument Sans from Google Fonts so it looks right on
+              its own. If your theme already loads Instrument Sans you can
+              delete the @import line near the top of the <style>.
+
+  All styles/JS are scoped under ".whya2" and prefixed "wa-" to avoid
+  colliding with your theme's CSS.
+============================================================================
+-->
+
+<style>
+/* Loads the brand font so the page is correct standalone.
+   DELETE this line if the live theme already loads Instrument Sans. */
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap');
+
+/* ---- design tokens (from why-a2.css :root) ---- */
+.whya2{
+  --ink:#0E0F11; --ink-2:#17191C; --carbon:#24272B;
+  --paper:#FFFFFF; --paper-2:#F4F3EF; --line:#E2DFD8;
+  --muted:#6A6F75; --muted-dk:#A7ABB0;
+  --accent:#E5322B; --accent-deep:#C32219; --on-accent:#FFFFFF;
+  --maxw:1240px; --gutter:clamp(20px,5vw,64px);
+  --shadow:0 1px 2px rgba(16,17,19,.05), 0 18px 40px -24px rgba(16,17,19,.28);
+
+  /* full-bleed: break out of the theme's centered content container so the
+     dark sections span the whole viewport width */
+  margin-left:calc(50% - 50vw);
+  margin-right:calc(50% - 50vw);
+  overflow-x:hidden;
+
+  font-family:'Instrument Sans',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  color:var(--ink);
+  line-height:1.5;
+  text-align:left;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+}
+.whya2 *{ box-sizing:border-box; }
+.whya2 h1,.whya2 h2,.whya2 h3,.whya2 p,.whya2 ul,.whya2 figure,.whya2 blockquote{ margin:0; }
+.whya2 a{ color:inherit; text-decoration:none; }
+.whya2 ul{ list-style:none; padding:0; }
+.whya2 img{ max-width:100%; display:block; }
+
+/* ---- shared building blocks ---- */
+.wa-wrap{ width:100%; max-width:var(--maxw); margin:0 auto; padding-left:var(--gutter); padding-right:var(--gutter); }
+.wa-sec{ padding:clamp(72px,9vw,128px) 0; }
+.wa-sec--paper{ background:var(--paper); }
+.wa-sec--paper2{ background:var(--paper-2); }
+.wa-sec--dark{ background:var(--ink); color:#fff; position:relative; }
+
+.wa-eyebrow{ text-transform:uppercase; font-weight:600; letter-spacing:.22em; font-size:.78rem; color:var(--accent); }
+.wa-sec--dark .wa-eyebrow{ color:#fff; }
+
+.wa-display{ font-size:clamp(2.5rem,6.4vw,5.4rem); font-weight:700; line-height:.98; letter-spacing:-.03em; }
+.wa-h2{ font-size:clamp(1.9rem,3.6vw,3rem); font-weight:700; line-height:1.04; letter-spacing:-.02em; }
+.wa-lede{ font-size:clamp(1.05rem,1.6vw,1.25rem); color:var(--muted); max-width:640px; }
+.wa-sec--dark .wa-lede{ color:var(--muted-dk); }
+.wa-head{ max-width:760px; }
+.wa-head .wa-h2{ margin-top:14px; }
+.wa-head .wa-lede{ margin-top:18px; }
+
+/* buttons */
+.wa-btn{ display:inline-flex; align-items:center; justify-content:center; gap:.5em;
+  font:inherit; font-weight:600; font-size:1rem; line-height:1; cursor:pointer;
+  padding:.95em 1.5em; min-height:48px; border-radius:4px; border:1px solid transparent;
+  transition:transform .18s ease, background .18s ease, border-color .18s ease; }
+.wa-btn--primary{ background:var(--accent); color:var(--on-accent); }
+.wa-btn--primary:hover{ background:var(--accent-deep); transform:translateY(-2px); }
+.wa-btn--ghost-light{ background:transparent; color:#fff; border-color:rgba(255,255,255,.45); }
+.wa-btn--ghost-light:hover{ border-color:#fff; transform:translateY(-2px); }
+
+/* image placeholders (labelled, so swap points are obvious) */
+.wa-ph{ position:relative; background:linear-gradient(135deg,#1b1d20,#0e0f11); }
+.wa-ph::after{ content:attr(data-label); position:absolute; inset:0; display:flex;
+  align-items:center; justify-content:center; text-align:center; padding:1rem;
+  font-size:.72rem; letter-spacing:.18em; text-transform:uppercase; color:rgba(255,255,255,.34); }
+.wa-ph--light{ background:linear-gradient(135deg,#ECEAE4,#F4F3EF); }
+.wa-ph--light::after{ color:rgba(20,22,24,.32); }
+
+/* ---- scroll reveal (progressive enhancement) ---- */
+/* base = visible; hiding only applies once JS adds .wa-anim, so if <script>
+   is stripped the content still shows */
+.whya2.wa-anim .reveal{ opacity:0; transform:translateY(26px);
+  transition:opacity .7s cubic-bezier(.16,.84,.44,1), transform .7s cubic-bezier(.16,.84,.44,1); }
+.whya2.wa-anim .reveal.is-in{ opacity:1; transform:none; }
+.whya2.wa-anim .reveal.d1{ transition-delay:.08s; }
+.whya2.wa-anim .reveal.d2{ transition-delay:.16s; }
+.whya2.wa-anim .reveal.d3{ transition-delay:.24s; }
+@media (prefers-reduced-motion:reduce){
+  .whya2.wa-anim .reveal{ opacity:1 !important; transform:none !important; transition:none !important; }
+}
+.whya2.no-motion .reveal{ opacity:1 !important; transform:none !important; transition:none !important; }
+
+/* =====================  1 · HERO  ===================== */
+.wa-hero{ position:relative; min-height:100svh; display:flex; align-items:flex-end; background:var(--ink); }
+.wa-hero-img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0; }
+.wa-hero-scrim{ position:absolute; inset:0; z-index:1;
+  background:
+    linear-gradient(90deg, rgba(14,15,17,.78), rgba(14,15,17,.12) 62%),
+    linear-gradient(0deg, rgba(14,15,17,.94), rgba(14,15,17,.10) 62%); }
+.wa-hero-inner{ position:relative; z-index:2; padding-top:140px; padding-bottom:clamp(72px,12vh,140px); }
+.wa-hero-inner .wa-display{ max-width:760px; color:#fff; margin-top:18px; }
+.wa-hero-sub{ max-width:620px; margin-top:22px; font-size:clamp(1.05rem,1.7vw,1.4rem); color:rgba(255,255,255,.84); }
+.wa-hero-sub b{ color:#fff; font-weight:700; }
+.wa-hero-cta{ display:flex; flex-wrap:wrap; gap:14px; margin-top:34px; }
+.wa-scrollcue{ position:absolute; left:50%; bottom:22px; transform:translateX(-50%); z-index:2;
+  font-size:.72rem; letter-spacing:.24em; text-transform:uppercase; color:rgba(255,255,255,.7);
+  display:flex; flex-direction:column; align-items:center; gap:8px; }
+.wa-scrollcue::after{ content:""; width:1px; height:34px; background:rgba(255,255,255,.55); animation:wa-cue 1.8s ease-in-out infinite; transform-origin:top; }
+@keyframes wa-cue{ 0%{ transform:scaleY(0); } 40%{ transform:scaleY(1); } 100%{ transform:scaleY(0); } }
+@media (max-width:600px){ .wa-scrollcue{ display:none; } }
+@media (prefers-reduced-motion:reduce){ .wa-scrollcue::after{ animation:none; } }
+
+/* =====================  2 · CREDIBILITY  ===================== */
+.wa-cred{ position:relative; }
+.wa-cred-bg{ position:absolute; inset:0; z-index:0; }
+.wa-cred-scrim{ position:absolute; inset:0; z-index:1; background:linear-gradient(0deg, rgba(14,15,17,.92), rgba(14,15,17,.74)); }
+.wa-cred .wa-wrap{ position:relative; z-index:2; }
+.wa-proof{ display:grid; grid-template-columns:repeat(3,1fr); gap:clamp(28px,4vw,56px); margin-top:clamp(40px,6vw,72px); }
+.wa-proof-item{ padding-top:22px; border-top:2px solid rgba(255,255,255,.16); }
+.wa-proof-num{ font-weight:700; font-size:1rem; color:var(--accent); letter-spacing:.04em; }
+.wa-proof-item h3{ font-size:clamp(1.2rem,1.8vw,1.45rem); font-weight:700; line-height:1.18; margin-top:14px; letter-spacing:-.01em; }
+.wa-proof-item p{ color:var(--muted-dk); margin-top:12px; font-size:1rem; }
+.wa-stars{ color:var(--accent); letter-spacing:.12em; margin-top:14px; font-size:1.05rem; }
+@media (max-width:760px){ .wa-proof{ grid-template-columns:1fr; } }
+
+/* =====================  3 · THE PROMISE  ===================== */
+.wa-cards3{ display:grid; grid-template-columns:repeat(3,1fr); gap:24px; margin-top:clamp(40px,5vw,64px); }
+.wa-card{ background:var(--paper); border:1px solid var(--line); border-radius:14px; padding:30px;
+  display:flex; flex-direction:column; min-height:300px;
+  transition:transform .22s ease, box-shadow .22s ease; }
+.wa-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-card-head{ font-size:clamp(1.5rem,2.2vw,1.9rem); font-weight:700; letter-spacing:-.02em; line-height:1.08; color:var(--ink); }
+.wa-card-head s{ color:var(--accent); text-decoration-thickness:2px; }
+.wa-card h3{ font-size:1.12rem; font-weight:700; margin-top:18px; color:var(--ink); }
+.wa-card p{ color:var(--muted); margin-top:10px; font-size:1rem; }
+.wa-tag{ margin-top:auto; padding-top:22px; text-transform:uppercase; letter-spacing:.16em; font-size:.72rem; font-weight:600; color:var(--accent); }
+@media (max-width:860px){ .wa-cards3{ grid-template-columns:1fr; } }
+
+/* =====================  4 · PRODUCT RANGE  ===================== */
+.wa-prod{ display:grid; grid-template-columns:repeat(2,1fr); gap:28px; margin-top:clamp(40px,5vw,64px); }
+.wa-prod-card{ display:flex; flex-direction:column; background:var(--paper); border:1px solid var(--line);
+  border-radius:14px; overflow:hidden; transition:transform .22s ease, box-shadow .22s ease; }
+.wa-prod-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-prod-media{ position:relative; aspect-ratio:16/11; background-size:cover; background-position:center;
+  transition:transform .4s ease; }
+.wa-prod-card:hover .wa-prod-media{ transform:scale(1.04); }
+.wa-prod-mediawrap{ overflow:hidden; }
+.wa-badge{ position:absolute; top:14px; left:14px; z-index:2; background:rgba(14,15,17,.7); color:#fff;
+  text-transform:uppercase; letter-spacing:.14em; font-size:.66rem; font-weight:600; padding:7px 11px; border-radius:3px; }
+.wa-prod-body{ padding:26px 28px 30px; }
+.wa-prod-row{ display:flex; align-items:baseline; justify-content:space-between; gap:14px; }
+.wa-prod-row h3{ font-size:clamp(1.5rem,2.4vw,2.1rem); font-weight:700; letter-spacing:-.02em; color:var(--ink); }
+.wa-price{ color:var(--muted); font-size:1rem; white-space:nowrap; }
+.wa-price b{ color:var(--ink); font-weight:700; }
+.wa-prod-body p{ color:var(--muted); margin-top:12px; }
+.wa-arrow{ display:inline-flex; align-items:center; gap:.4em; color:var(--accent); font-weight:600; margin-top:18px; }
+.wa-prod-card:hover .wa-arrow span{ transform:translateX(4px); }
+.wa-arrow span{ transition:transform .2s ease; }
+@media (max-width:820px){ .wa-prod{ grid-template-columns:1fr; } }
+
+/* =====================  5 · ATHLETE PROOF  ===================== */
+.wa-ath{ display:grid; grid-template-columns:repeat(3,1fr); gap:24px; margin-top:clamp(40px,5vw,64px); }
+.wa-ath-card{ background:var(--paper); border:1px solid var(--line); border-radius:14px; overflow:hidden;
+  display:flex; flex-direction:column; transition:transform .22s ease, box-shadow .22s ease; }
+.wa-ath-card:hover{ transform:translateY(-4px); box-shadow:var(--shadow); }
+.wa-ath-photo{ aspect-ratio:4/3; background-size:cover; background-position:center; }
+.wa-ath-body{ padding:26px 26px 28px; display:flex; flex-direction:column; flex:1; }
+.wa-ath-body blockquote{ position:relative; padding-top:22px; color:var(--ink); font-size:1.08rem; line-height:1.45; }
+.wa-ath-body blockquote::before{ content:""; position:absolute; top:0; left:0; width:30px; height:3px; background:var(--accent); }
+.wa-ath-name{ font-weight:700; margin-top:20px; color:var(--ink); }
+.wa-ath-race{ color:var(--muted); font-size:.95rem; margin-top:4px; }
+@media (max-width:860px){
+  .wa-ath{ grid-template-columns:1fr; }
+  .wa-ath-card{ max-width:460px; margin:0 auto; width:100%; }
+}
+
+/* =====================  6 · EMAIL CAPTURE  ===================== */
+.wa-capture{ position:relative; overflow:hidden; }
+.wa-capture::before{ content:""; position:absolute; top:-30%; right:-10%; width:60%; height:120%; z-index:0;
+  background:radial-gradient(closest-side, rgba(229,50,43,.4), rgba(229,50,43,0) 70%); pointer-events:none; }
+.wa-capture .wa-wrap{ position:relative; z-index:1; }
+.wa-capture-inner{ max-width:720px; margin:0 auto; text-align:center; }
+.wa-capture-inner .wa-h2{ margin-top:14px; }
+.wa-capture-inner .wa-lede{ margin:18px auto 0; color:var(--muted-dk); }
+.wa-form{ display:flex; gap:12px; margin:30px auto 0; max-width:520px; }
+.wa-form input[type=email]{ flex:1; min-width:0; font:inherit; font-size:1rem; padding:.95em 1.1em; min-height:48px;
+  border-radius:4px; border:1px solid rgba(255,255,255,.22); background:rgba(255,255,255,.06); color:#fff; }
+.wa-form input[type=email]::placeholder{ color:rgba(255,255,255,.55); }
+.wa-form input[type=email]:focus{ outline:none; border-color:var(--accent); }
+.wa-trust{ margin-top:16px; font-size:.85rem; color:var(--muted-dk); }
+.wa-form-success{ display:none; margin:30px auto 0; max-width:520px; padding:20px; border-radius:8px;
+  border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.05); color:#fff; font-weight:600; }
+@media (max-width:520px){ .wa-form{ flex-direction:column; } }
+</style>
+
+
+<div class="whya2">
+
+  <!-- =====================  1 · HERO  ===================== -->
+  <section class="wa-hero wa-sec--dark">
+    <!-- REPLACE: hero must be an ACTION/RIDING shot (not studio). Using a real A2 photo as a stand-in. -->
+    <img class="wa-hero-img" src="https://a2bikes.com/cdn/shop/files/P1000484-Edit.jpg" alt="A2 triathlon bike" loading="eager" fetchpriority="high">
+    <div class="wa-hero-scrim"></div>
+    <div class="wa-wrap wa-hero-inner">
+      <p class="wa-eyebrow reveal">Rider Focused. Always.</p>
+      <h1 class="wa-display reveal d1">Pro-level triathlon bikes.<br>Without the pro-level price.</h1>
+      <p class="wa-hero-sub reveal d2">The same design pedigree as a <b>Cervélo P-Series</b> — drawn by the engineer who shaped it — sold direct, so you skip the retail markup.</p>
+      <div class="wa-hero-cta reveal d3">
+        <a class="wa-btn wa-btn--primary" href="/collections/sp">See the bikes →</a>
+        <a class="wa-btn wa-btn--ghost-light" href="#wa-capture">Get our sizing guide</a>
+      </div>
+    </div>
+    <div class="wa-scrollcue" aria-hidden="true">Scroll</div>
+  </section>
+
+  <!-- =====================  2 · CREDIBILITY  ===================== -->
+  <section class="wa-sec wa-sec--dark wa-cred">
+    <!-- REPLACE: race photo. data-label shows until you add a background-image. -->
+    <div class="wa-cred-bg wa-ph" data-label="Race photo — replace"></div>
+    <div class="wa-cred-scrim"></div>
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">Proven, not promised</p>
+        <h2 class="wa-h2">Designed by Kevin Quan.<br>Tested at Kona.</h2>
+      </div>
+      <div class="wa-proof">
+        <div class="wa-proof-item reveal d1">
+          <div class="wa-proof-num">01</div>
+          <h3>Drawn by a former Cervélo P-Series engineer</h3>
+          <p>A2's geometry comes from Kevin Quan — the engineer behind the Cervélo P-Series, one of the most successful triathlon bikes ever made.</p>
+        </div>
+        <div class="wa-proof-item reveal d2">
+          <div class="wa-proof-num">02</div>
+          <h3>Trusted at the Ironman World Championships</h3>
+          <p>A2 bikes have been raced on the lava fields of Kona — the toughest proving ground in the sport.</p>
+        </div>
+        <div class="wa-proof-item reveal d3">
+          <div class="wa-proof-num">03</div>
+          <h3>Best Beginner Triathlon Bike</h3>
+          <div class="wa-stars" aria-label="5 out of 5 stars">★★★★★</div>
+          <p>Named by Triathlete Magazine — a five-time winner of the category.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- =====================  3 · THE PROMISE  ===================== -->
+  <section class="wa-sec wa-sec--paper2">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">The A2 promise</p>
+        <h2 class="wa-h2">What you don't pay for</h2>
+        <p class="wa-lede">A2 sells direct. That means your money goes into the bike — not the markup, the middleman, or next year's "upgrade."</p>
+      </div>
+      <div class="wa-cards3">
+        <article class="wa-card reveal d1">
+          <div class="wa-card-head"><s>No</s> retail markup</div>
+          <h3>Sold direct, priced honestly</h3>
+          <p>Big brands build dealer margin and retail markup into the price. We don't. You pay for engineering and materials — nothing else.</p>
+          <div class="wa-tag">Direct-to-rider</div>
+        </article>
+        <article class="wa-card reveal d2">
+          <div class="wa-card-head"><s>No</s> dealer middleman</div>
+          <h3>Ships from Oregon, set up at home</h3>
+          <p>No showroom upsell. Your bike ships from our Oregon shop, ready to finish assembly at home with our step-by-step guides.</p>
+          <div class="wa-tag">Pacific Northwest built</div>
+        </article>
+        <article class="wa-card reveal d3">
+          <div class="wa-card-head"><s>No</s> annual obsolescence</div>
+          <h3>Lifetime warranty, free size exchanges</h3>
+          <p>We don't chase yearly model cycles. Your A2 is backed by a lifetime frame warranty and free size exchanges if the fit isn't right.</p>
+          <div class="wa-tag">Backed for life</div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- =====================  4 · PRODUCT RANGE  ===================== -->
+  <section class="wa-sec wa-sec--paper">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">The lineup</p>
+        <h2 class="wa-h2">Find your A2</h2>
+        <p class="wa-lede">Two platforms, one obsession: fast bikes that fit real riders — priced direct.</p>
+      </div>
+      <div class="wa-prod">
+        <a class="wa-prod-card reveal d1" href="/pages/sp">
+          <div class="wa-prod-mediawrap">
+            <!-- Real A2 SP photo -->
+            <div class="wa-prod-media" style="background-image:url('https://a2bikes.com/cdn/shop/files/DSCF9443-Edit-Edit.jpg')">
+              <span class="wa-badge">Triathlon</span>
+            </div>
+          </div>
+          <div class="wa-prod-body">
+            <div class="wa-prod-row">
+              <h3>SP</h3>
+              <div class="wa-price">from <b>$3,115</b></div>
+            </div>
+            <p>Our triathlon and time-trial machine — superbike aerodynamics and fit, without the superbike price.</p>
+            <div class="wa-arrow">Explore the SP <span>→</span></div>
+          </div>
+        </a>
+        <a class="wa-prod-card reveal d2" href="/pages/rogue">
+          <div class="wa-prod-mediawrap">
+            <!-- REPLACE: Rogue photo -->
+            <div class="wa-prod-media wa-ph wa-ph--light" data-label="Rogue photo — replace">
+              <span class="wa-badge">Road &amp; Gravel</span>
+            </div>
+          </div>
+          <div class="wa-prod-body">
+            <div class="wa-prod-row">
+              <h3>Rogue</h3>
+              <div class="wa-price">from <b>$2,699</b></div>
+            </div>
+            <p>One bike for road and gravel — fast on pavement, capable when the pavement ends.</p>
+            <div class="wa-arrow">Explore the Rogue <span>→</span></div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- =====================  5 · ATHLETE PROOF  ===================== -->
+  <section class="wa-sec wa-sec--paper2">
+    <div class="wa-wrap">
+      <div class="wa-head reveal">
+        <p class="wa-eyebrow">Race proven</p>
+        <h2 class="wa-h2">Ridden by the A2 Racing Team</h2>
+      </div>
+      <div class="wa-ath">
+        <article class="wa-ath-card reveal d1">
+          <!-- REPLACE: athlete photo -->
+          <div class="wa-ath-photo wa-ph wa-ph--light" data-label="Athlete photo — replace"></div>
+          <div class="wa-ath-body">
+            <!-- REPLACE: add Kinley's real quote (result below is verified). -->
+            <blockquote>[Add Kinley's quote here]</blockquote>
+            <div class="wa-ath-name">Kinley Bollinger</div>
+            <div class="wa-ath-race">1st Overall — Ironman 70.3 Puerto Rico · 4:40:39</div>
+          </div>
+        </article>
+        <article class="wa-ath-card reveal d2">
+          <div class="wa-ath-photo wa-ph wa-ph--light" data-label="Athlete photo — replace"></div>
+          <div class="wa-ath-body">
+            <blockquote>[Athlete quote]</blockquote>
+            <div class="wa-ath-name">[Athlete name]</div>
+            <div class="wa-ath-race">[Race / achievement]</div>
+          </div>
+        </article>
+        <article class="wa-ath-card reveal d3">
+          <div class="wa-ath-photo wa-ph wa-ph--light" data-label="Athlete photo — replace"></div>
+          <div class="wa-ath-body">
+            <blockquote>[Athlete quote]</blockquote>
+            <div class="wa-ath-name">[Athlete name]</div>
+            <div class="wa-ath-race">[Race / achievement]</div>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- =====================  6 · EMAIL CAPTURE (primary goal)  ===================== -->
+  <section id="wa-capture" class="wa-sec wa-sec--dark wa-capture">
+    <div class="wa-wrap">
+      <div class="wa-capture-inner reveal">
+        <p class="wa-eyebrow">Free sizing guide</p>
+        <h2 class="wa-h2">Sizing a triathlon bike is harder than it should be.</h2>
+        <p class="wa-lede">Get our free guide and we'll help you dial in the right frame size, fit, and setup — before you ever click "buy."</p>
+
+        <!--
+          REPLACE the form below with your Klaviyo embed, then delete the form + .wa-form-success:
+          <div class="klaviyo-form-XXXXXXX"></div>
+          (Make sure the Klaviyo onsite script is loaded in theme.liquid, and hook
+           this form to the "Welcome to A2" flow.)
+        -->
+        <form class="wa-form" novalidate>
+          <input type="email" name="email" placeholder="you@email.com" aria-label="Email address" required>
+          <button type="submit" class="wa-btn wa-btn--primary">Send me the guide</button>
+        </form>
+        <div class="wa-form-success">Check your inbox — your sizing guide is on the way. ✓</div>
+
+        <p class="wa-trust">No spam. Unsubscribe anytime.</p>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+
+<script>
+(function () {
+  var root = document.querySelector('.whya2');
+  if (!root) return;
+
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Enable reveal animations only now that JS runs (keeps content visible if JS is stripped).
+  if (!reduce) root.classList.add('wa-anim');
+
+  var items = root.querySelectorAll('.reveal');
+  function reveal() {
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    for (var i = 0; i < items.length; i++) {
+      var el = items[i];
+      if (el.classList.contains('is-in')) continue;
+      if (el.getBoundingClientRect().top < vh * 0.88) el.classList.add('is-in');
+    }
+  }
+  reveal();
+  window.addEventListener('scroll', reveal, { passive: true });
+  window.addEventListener('resize', reveal);
+  window.addEventListener('load', reveal);
+
+  // Smooth-scroll for in-page anchors (e.g. the "Get our sizing guide" CTA).
+  var anchors = root.querySelectorAll('a[href^="#"]');
+  for (var a = 0; a < anchors.length; a++) {
+    anchors[a].addEventListener('click', function (e) {
+      var id = this.getAttribute('href');
+      if (id.length > 1) {
+        var target = document.querySelector(id);
+        if (target) {
+          e.preventDefault();
+          target.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' });
+        }
+      }
+    });
+  }
+
+  // Mock success state for the placeholder form. REMOVE once Klaviyo handles submission.
+  var form = root.querySelector('.wa-form');
+  if (form) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var ok = root.querySelector('.wa-form-success');
+      if (ok) { form.style.display = 'none'; ok.style.display = 'block'; }
+    });
+  }
+})();
+</script>


### PR DESCRIPTION
## What this delivers

The **"Why A2"** brand/trust landing page (from the design handoff), in **two forms**:

### 1. Theme section (the chosen approach — drag-and-drop editable) ✅ set up in the store
- `theme/sections/why-a2.liquid` — all 6 sections (Hero → Credibility → Promise → Product range → Athlete proof → Email capture) with **65 editable settings**: every image is an `image_picker`, plus editable copy, prices, links, and a Klaviyo form ID field.
- `theme/templates/page.why-a2.json` — page template that renders the section.

CSS/JS are wrapped in `{% raw %}` so Liquid never trips on the braces; scroll-reveal is progressive-enhancement (visible if JS is absent). Schema JSON validated (no duplicate IDs, all labels ≤70 chars, every referenced setting defined).

**Store setup performed via the Shopify Admin API (live site untouched):**
- Duplicated the live theme → unpublished **"Why A2 — DRAFT (preview, do not publish yet)"**.
- Wrote the section + template into that draft theme (verified present, 31.5 KB section).
- Created the **Why A2** page (`/pages/why-a2`) on the `why-a2` template.
- Did **not** publish anything — the merchant publishes the draft theme when ready.

### 2. Self-contained HTML page (alternative)
- `why-a2-shopify-page.html` — the same design as one copy-paste block (inline CSS/JS) for pasting into a Shopify *page's* HTML editor. Kept as a fallback / reference.

## Before launch
- Set the **hero** image to an action/riding shot (not studio) and the other images via the theme editor's pickers.
- Add **Kinley Bollinger's** real quote (result is verified); replace athlete cards 2 & 3.
- Paste the **Klaviyo** form ID into the section settings (and ensure the onsite script is in `theme.liquid`).

https://claude.ai/code/session_012xhTxfvAEjycRj1WhxuyX3