### PR TITLE
Visitor-ID plays 1–9: capture mechanisms + CRM wiring (draft)

### DIFF
--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -119,7 +119,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
 | 5 | Push the Octane quiz | `quiz` | **built + staged** | Octane app embed has a BLANK quiz id — confirm the quiz destination (page vs on-site) |
 | 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
-| 7 | Sign in with Shop | `checkout` | not started | — |
+| 7 | Sign in with Shop | `account` | **theme wiring built + staged** | ENABLE Sign in with Shop in admin (Settings → Customer accounts) — owner action |
 | 8 | Zoho chat asks email early | `chat` | not started | — |
 | 9 | Financing prequal step | `save_build`/new | not started | — |
 
@@ -216,6 +216,23 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   the `band` style; switch to `strip` or restyle in the editor. To push on PDPs,
   drop the "A2 Quiz CTA" section onto the product template at the prominence you
   want.
+
+### Play 7 — Sign in with Shop (this build)
+- Reality: enabling "Sign in with Shop" is a **Shopify admin toggle** (Settings →
+  Customer accounts / Checkout), not theme code. The store currently uses classic
+  customer accounts (`sections/main-customer-login.liquid`, email/password); no
+  Shop sign-in button in the theme.
+- **Theme wiring shipped:** `layout/theme.liquid` auto-identified logged-in
+  customers to Klaviyo/GA4 (`a2IdentifyVisitor`) but never to the CRM. Added a
+  guarded `window.a2_identify(customer.email, "account")` in the `{% if customer %}`
+  block, so returning known customers — including Shop Pay / Sign in with Shop
+  returners once enabled — land on the scoreboard (source `account`). Idempotent
+  per person, so repeated pageviews are fine. Verbatim base preserved; checksum
+  `fdac5f26d5aeac036658a61ab591ff33`.
+- **Owner action (the actual enablement):** turn on **Sign in with Shop** in
+  Shopify admin → Settings → Customer accounts (and/or Checkout). Optional theme
+  add (not built, low value until enabled): a `<shop-login-button>` (shop-js) on
+  the login page — say the word and I'll stage it.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -116,7 +116,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 1 | Exit-intent capture (+ $X off) | `exit_intent` | **built + staged (disabled)** | discount **amount + code**, Klaviyo list id, final copy |
 | 2 | Email-gate Fit Calculator | `fit_calculator` | **built + staged** | none — owner confirmed geometry current; soft gate chosen |
 | 3 | Save-your-build on PDPs | `save_build` | **built + staged** | needs a Klaviyo "Saved Build" flow + list to actually send the quote email |
-| 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
+| 4 | Email flows as identity machines | `newsletter`/`klaviyo_form`/`contact` | **built + staged** | Klaviyo flow coordination (email-click cookies already captured via `_kx` in a2-lp.js) |
 | 5 | Push the Octane quiz | `quiz` | **built + staged** | Octane app embed has a BLANK quiz id — confirm the quiz destination (page vs on-site) |
 | 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
 | 7 | Sign in with Shop | `account` | **theme wiring built + staged** | ENABLE Sign in with Shop in admin (Settings → Customer accounts) — owner action |
@@ -233,6 +233,28 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   Shopify admin → Settings → Customer accounts (and/or Checkout). Optional theme
   add (not built, low value until enabled): a `<shop-login-button>` (shop-js) on
   the login page — say the word and I'll stage it.
+
+### Play 4 — email flows as identity machines (this build)
+- Every email-capture path reached Klaviyo/GA4 but never the CRM scoreboard.
+  Wired all of them (verbatim bases verified byte-identical before editing):
+  - `layout/theme.liquid` — the Klaviyo native-form (`klaviyoForms`) listener now
+    also calls `a2_identify(email, "klaviyo_form")`; the newsletter/contact submit
+    handler now calls `a2_identify(email, form_type=="contact" ? "contact" :
+    "newsletter")` (Shopify newsletter + contact forms both POST to /contact, so
+    `form_type` is the reliable discriminator). Checksum
+    `f8841abd504b4f6af2307b6f68af7ea0`.
+  - `assets/a2-lp.js` — the shared `data-a2-klaviyo-form` submit handler (used by
+    the reusable `a2-email-capture` component + LP forms) now calls
+    `a2_identify(email, data-a2-crm-source || "newsletter")` once the email is
+    valid, before the Klaviyo POST — so it fires even when Klaviyo keys aren't
+    set. **UTM/attribution capture untouched** (hard rule). Checksum
+    `8764e2e9798b73df08a144a2d51b8787`. Forms can set `data-a2-crm-source` for
+    precise per-form attribution; default is `newsletter`.
+- **Already in place (no build needed):** a2-lp.js captures Klaviyo click ids
+  (`_kx`) as first-touch attribution, so email clicks that land with `?_kx=` are
+  cookied — the "email flows cookie the browser for ~2 years" mechanism. The
+  remaining work is **Klaviyo flow coordination** (owner/Klaviyo side): make sure
+  flows link back to the site so clicks re-identify returning browsers.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -115,7 +115,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 |---|---|---|---|---|
 | 1 | Exit-intent capture (+ $X off) | `exit_intent` | **built + staged (disabled)** | discount **amount + code**, Klaviyo list id, final copy |
 | 2 | Email-gate Fit Calculator | `fit_calculator` | **built + staged** | none — owner confirmed geometry current; soft gate chosen |
-| 3 | Save-your-build on PDPs | `save_build` | not started | — |
+| 3 | Save-your-build on PDPs | `save_build` | **built + staged** | needs a Klaviyo "Saved Build" flow + list to actually send the quote email |
 | 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
 | 5 | Push the Octane quiz | `quiz` | not started | quiz placement prominence |
 | 6 | Back-in-stock / price-drop | `restock_alert` | not started | verify existing `snippets/a2-restock-alert.liquid` |
@@ -150,6 +150,27 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   follow-up if we want to gate that surface too. The `a2-size-calc.liquid`
   out-of-range lead form also does not yet call `a2_identify` (only Klaviyo) —
   small follow-up to tag it `fit_calculator`.
+
+### Play 3 — Save your build / email me the quote (this build)
+- New snippet `shopify/snippets/a2-save-build.liquid` (self-contained; a2-lp.js
+  is NOT on PDPs). Rendered on bike PDPs by `sections/sppdp-product.liquid`
+  right after the Add-to-Cart form, gated by section setting `enable_save_build`
+  (default on), with `sb_klaviyo_company` (default `YejYTH`) + `sb_klaviyo_list`.
+- Reads the live build from `window.A2_FIT_CTX` (model/build/productTitle/url) +
+  the buy-box DOM: `[data-price]` (live price), the active `.build-pill`
+  (groupset), and selected options `[data-opt][aria-pressed="true"]`.
+- On submit: `a2_identify(email,"save_build")` + `a2IdentifyVisitor` + Klaviyo
+  subscription (custom_source `save_build`) with the build in profile properties
+  + a "Saved Build" Klaviyo event + `dataLayer` `save_build_email_capture`.
+- Staged to draft `176605397156` via staged-upload pipeline; checksums verified:
+  snippet `5103078a7ada602d61dacf4388ff078d`, `sppdp-product.liquid`
+  `c3256c31c03eb7255baf776fee82c2bc`. Verbatim copy of the section verified
+  byte-identical to live before the 2-line edit.
+- **Owner to-do (not a code blocker):** build a Klaviyo flow triggered by the
+  `save_build` list (or the "Saved Build" event) that emails the spec + price,
+  so the "check your inbox" promise is fulfilled. Set `sb_klaviyo_list` to that
+  list. Note `A2_FIT_CTX.price` is the base product price; the emailed quote uses
+  the live `[data-price]` DOM value scraped at submit.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -121,7 +121,34 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
 | 7 | Sign in with Shop | `account` | **theme wiring built + staged** | ENABLE Sign in with Shop in admin (Settings → Customer accounts) — owner action |
 | 8 | Zoho chat asks email early | `chat` | **theme capture built + staged** | Zoho dashboard: turn on pre-chat email field + (best) a webhook → oryguntri.com/api/identify |
-| 9 | Financing prequal step | `save_build`/new | not started | — |
+| 9 | Financing prequal step | (Affirm-native; no CRM source) | **already compliant in theme — no new code** | owner: enable `show_affirm_line` (built-in) OR keep the Affirm app block (not both); route copy via Affirm Merchant Care |
+
+## Build status — all 9 plays addressed
+
+Plays 1–8 are **built + staged** to the draft theme (checksums verified); Play 9
+is **already compliant in the theme** (no new code — see below). Every capture
+mechanism now calls `window.a2_identify(email, <source>)` with the correct source
+string, so each shows up on the CRM "How we identify people" scoreboard.
+
+### Consolidated owner checklist before publishing
+1. **Play 1 (exit-intent):** set discount **amount + code** + Klaviyo **list id**,
+   review copy, tick **Enable** (section is off until then).
+2. **Play 3 (save-build):** build a Klaviyo "Saved Build" flow and set
+   `sb_klaviyo_list` so the quote email actually sends.
+3. **Play 4:** coordinate Klaviyo flows (email-click `_kx` already cookied).
+4. **Play 5 (quiz):** confirm the quiz destination — the Octane app embed has a
+   **blank quiz id**; the CTA falls back to `/pages/a2-bikes-selector-quiz`.
+5. **Play 6 (restock):** set the `custom.restock_alert` metafield on the SP
+   product(s) you want the card on. (Price-drop = future follow-up.)
+6. **Play 7 (Sign in with Shop):** enable it in Shopify admin → Settings →
+   Customer accounts.
+7. **Play 8 (chat):** turn on the Zoho pre-chat email field; add a Zoho webhook →
+   `oryguntri.com/api/identify` for the most reliable capture.
+8. **Play 9 (financing):** choose built-in Affirm line vs. Affirm app block (one,
+   not both); send any new financing copy to Affirm Merchant Care for review.
+9. **Publish:** re-duplicate the current live theme, re-apply these repo files
+   (or publish this draft after re-syncing it to current live), and publish.
+   Owner publishes — never the agent.
 
 ### Shared staged draft theme
 - **Draft theme `176605397156`** — "A2 Visitor-ID — Plays 1–2 (draft, do not
@@ -270,6 +297,30 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   https://oryguntri.com/api/identify` `{email, source:"chat"}`** (server-side path
   from the CRM contract) — the client-side hooks above are best-effort and depend
   on which SalesIQ callbacks fire for your plan/config.
+
+### Play 9 — financing prequal (assessed; no build needed)
+- **Verified Affirm-compliant and already implemented** in `sections/sppdp-product.liquid`:
+  the buy box (and sticky bar) render Affirm's OWN `.affirm-as-low-as` component
+  (`data-page-type="product"`, `data-amount="{{ cur.price }}"`) which shows
+  "As low as $X/mo · See if you qualify" and opens Affirm's educational/prequal
+  modal carrying the TILA representative example + lender disclosures. Variant
+  changes call `affirm.ui.refresh()`; affirm.js is loaded guarded. This IS the
+  "see your monthly payment → prequal at the decision moment" mechanism.
+- **No non-compliant custom figure:** the `monthly = price ÷ months` Liquid var is
+  computed but never rendered (dead code from `affirm_months`); nothing hardcodes
+  a "$X/mo". Left as-is (harmless); could be removed in a future cleanup.
+- **Why no new code:** Affirm's policy requires using their component for payment
+  messaging (never a custom calculator), keeping the disclosures, and not implying
+  guaranteed approval. A bespoke "see your monthly payment" widget would violate
+  that. The compliant component already exists — the only work is activation.
+- **Owner actions:** (1) decide built-in line (`show_affirm_line`, default off)
+  vs. the official Affirm app block — show ONE, not both; (2) submit any new
+  financing copy/banners to **Affirm Merchant Care** for review (~5–10 business
+  days) before publishing. See the compliance notes: Affirm Compliance &
+  Guidelines; Promotional Messaging & Prequalification.
+- **CRM note:** prequal runs inside Affirm's UI, so no email reaches us — Play 9
+  has **negligible identification value** (it's a conversion play). No
+  `a2_identify` wiring is possible/appropriate here.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -117,7 +117,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 2 | Email-gate Fit Calculator | `fit_calculator` | **built + staged** | none — owner confirmed geometry current; soft gate chosen |
 | 3 | Save-your-build on PDPs | `save_build` | **built + staged** | needs a Klaviyo "Saved Build" flow + list to actually send the quote email |
 | 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
-| 5 | Push the Octane quiz | `quiz` | not started | quiz placement prominence |
+| 5 | Push the Octane quiz | `quiz` | **built + staged** | Octane app embed has a BLANK quiz id — confirm the quiz destination (page vs on-site) |
 | 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
 | 7 | Sign in with Shop | `checkout` | not started | — |
 | 8 | Zoho chat asks email early | `chat` | not started | — |
@@ -190,6 +190,32 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 - **Follow-up (separate mechanism):** price-drop alerts. Not in this card; best
   done via Klaviyo's native price-drop / a parallel "price drop" capture card
   wired to a new `price_drop` source. Flagged, not built.
+
+### Play 5 — push the Octane quiz (this build)
+- New section `shopify/sections/a2-quiz-cta.liquid` (self-contained; no a2-lp.js
+  dependency, so it works on homepage AND PDPs). Opens the quiz (prefers the
+  Octane on-site JS API, falls back to the quiz page URL, default
+  `/pages/a2-bikes-selector-quiz`) and pushes the `octane_quiz_open` dataLayer
+  event. In-page band/strip (owner-selectable prominence), NOT a popup. Has
+  presets so the owner can drop it on PDPs (or anywhere) via the theme editor.
+- Added to the homepage: `shopify/templates/index.json` now includes a
+  `quiz_band` (type `a2-quiz-cta`, style band) right after the `lineup` section.
+- **Measurement fix (the key part):** `layout/theme.liquid`'s
+  `octane-quiz-completed` message listener previously called only
+  `a2IdentifyVisitor`. Added a guarded `window.a2_identify(email, "quiz")` in
+  both branches so quiz completions are tagged `quiz` on the CRM scoreboard.
+- Staged to draft `176605397156`; checksums verified — section
+  `55368c717714dedc68eaa4ed2bb1091f`, `layout/theme.liquid`
+  `c0dd3041741b9d40bebf858f17510532`, `templates/index.json`
+  `b806a5ba0e15909f523a1a5f201e6641`. (Section schema initially rejected a blank
+  text default on `foot`; fixed.) Both live files verified byte-identical before
+  the surgical edits.
+- **Owner notes:** the Octane app embed is enabled but has a **blank quiz id**,
+  so the reliable destination is the quiz page — confirm `/pages/a2-bikes-selector-quiz`
+  is the intended quiz (or set the section's Quiz URL). Homepage prominence is
+  the `band` style; switch to `strip` or restyle in the editor. To push on PDPs,
+  drop the "A2 Quiz CTA" section onto the product template at the prominence you
+  want.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -114,7 +114,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | # | Play | Source string | Status | Owner decisions blocking launch |
 |---|---|---|---|---|
 | 1 | Exit-intent capture (+ $X off) | `exit_intent` | **built + staged (disabled)** | discount **amount + code**, Klaviyo list id, final copy |
-| 2 | Email-gate Fit Calculator | `fit_calculator` | not started | **confirm current SP geometry (S/M/L/XL, not 2021 XS–L)** |
+| 2 | Email-gate Fit Calculator | `fit_calculator` | **built + staged** | none — owner confirmed geometry current; soft gate chosen |
 | 3 | Save-your-build on PDPs | `save_build` | not started | — |
 | 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
 | 5 | Push the Octane quiz | `quiz` | not started | quiz placement prominence |
@@ -123,10 +123,36 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 8 | Zoho chat asks email early | `chat` | not started | — |
 | 9 | Financing prequal step | `save_build`/new | not started | — |
 
-### Play 1 — exit-intent (this build)
-- **Staged draft theme:** `176605397156` — "A2 Visitor-ID — Exit Intent (draft,
-  do not publish)" (duplicate of the 07‑18 live theme). Preview:
-  `https://a2bikes.com/?preview_theme_id=176605397156`
+### Shared staged draft theme
+- **Draft theme `176605397156`** — "A2 Visitor-ID — Plays 1–2 (draft, do not
+  publish)" (duplicate of the 07‑18 live theme) now holds **both** Play 1 and
+  Play 2. Preview: `https://a2bikes.com/?preview_theme_id=176605397156`
+  New plays stage into this same theme so the owner can preview/publish one theme.
+
+### Play 2 — email-gate the Fit Calculator (this build)
+- Finished the existing redesign `shopify/snippets/a2-fit-engine.liquid`
+  (rendered on SP/Rogue PDPs by `sections/sppdp-product.liquid`, `#find-your-fit`
+  drawer). Two surgical changes, verbatim copy verified byte-identical to live
+  before editing:
+  1. **CRM wiring:** `sendFit()` now calls `window.a2_identify(email,
+     "fit_calculator")` before the existing Klaviyo "Requested Fit Results" +
+     `a2dl` calls. This is what makes fit captures show on the scoreboard.
+  2. **Soft gate (owner-approved):** verdict (recommended size) stays visible;
+     the full breakdown (pad/bar coords, drop, setup) + chart blur-lock behind
+     the email submit, revealed on success. Blur-lock (no DOM removal). Toggle
+     `A2FE_GATE` (`"soft"`/`"off"`) at the top of the IIFE. Covers both inline
+     and drawer mounts.
+- Staged to draft `176605397156` via the staged-upload pipeline
+  (`stagedUploadsCreate` → `curl PUT` → `themeFilesUpsert` URL body); checksum
+  verified `c33d603a7dc866e9368395a36e96e564` == local md5.
+- **Notes / follow-ups:** the older inline Pad X/Y `a2-fit-calculator.liquid`
+  (on line LPs via `a2-line-lp.liquid`) still has NO email capture — separate
+  follow-up if we want to gate that surface too. The `a2-size-calc.liquid`
+  out-of-range lead form also does not yet call `a2_identify` (only Klaviyo) —
+  small follow-up to tag it `fit_calculator`.
+
+### Play 1 — exit-intent
+- Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`
   Both files verified byte-identical via `checksumMd5`:
   `sections/a2-exit-intent.liquid` = `e1a8b60b3d8cdb422a1b90a205b4b374`,
   `sections/overlay-group.json` = `af383db96059a53f81cd50fdbada1f55`.

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -124,6 +124,15 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 9 | Financing prequal step | `save_build`/new | not started | — |
 
 ### Play 1 — exit-intent (this build)
+- **Staged draft theme:** `176605397156` — "A2 Visitor-ID — Exit Intent (draft,
+  do not publish)" (duplicate of the 07‑18 live theme). Preview:
+  `https://a2bikes.com/?preview_theme_id=176605397156`
+  Both files verified byte-identical via `checksumMd5`:
+  `sections/a2-exit-intent.liquid` = `e1a8b60b3d8cdb422a1b90a205b4b374`,
+  `sections/overlay-group.json` = `af383db96059a53f81cd50fdbada1f55`.
+- To preview the popup: theme editor → this draft → set **Offer amount** +
+  **Discount code**, tick **Enable**, save, then trigger exit intent (move the
+  cursor out the top of the window on desktop).
 - `shopify/sections/a2-exit-intent.liquid` — self-contained global overlay
   (own CSS+JS, does not depend on a2-lp.js). Added to `overlay-group.json`.
 - Ships **disabled by default** (`enable` setting off) and with a **blank

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -1,0 +1,134 @@
+# A2 Bikes — Visitor-Identification Build ("The Plays")
+
+Working doc for the visitor-ID capture build-out. Goal: raise the
+identification rate from ~4% of new visitors to 15% (30 days) / 25%+ (90 days)
+by adding **first-party email-capture mechanisms** across a2bikes.com. The CRM
+plumbing (OrygunTri) is already live; the only thing we wire is the identify
+call. See the mission brief for the full play list.
+
+> This repo was found effectively empty at the start of this build (only
+> `README.md`). The live Shopify theme is the de-facto source of truth. New
+> work is authored here in `shopify/` first, then staged to a **draft** theme.
+
+---
+
+## Verified environment (checked via Admin API 2026-07-20 — supersedes the brief)
+
+The brief's theme IDs were stale. Verified live state:
+
+| Theme | ID | Role | Notes |
+|---|---|---|---|
+| **Live Theme 7_15 Duplicate before** | `176596517028` | **MAIN (LIVE)** | Current published theme (updated 07‑18). This is the real live theme — **never write to it.** |
+| Live 7/13 | `176591470756` | unpublished | Old live snapshot. The brief called this the "restock-alert draft" — it is **not**; it's just an old live copy. |
+| Why A2 — SP Collection LP (current…) | `176582197412` | unpublished | draft |
+| SP drop v4 — bike+size | `176596058276` | unpublished | draft |
+| Live + Rogue Collection LP (ready to publish) | `176596189348` | unpublished | draft |
+| Size Guide redesign — preview | `176591601828` | unpublished | draft |
+| (…10 more unpublished themes) | | | see `themes` query |
+
+- The brief said the "Why A2" theme became LIVE around 2026‑07‑06. As of 07‑18
+  the MAIN theme is **"Live Theme 7_15 Duplicate before"** (`176596517028`).
+  Always re-verify before writing:
+  `query { themes(first:25){ nodes{ id name role updatedAt } } }`
+
+### Hard rule: never publish, never write to MAIN
+All work goes into a **duplicate draft** theme. The owner publishes.
+
+---
+
+## CRM integration contract (already live — we only call it)
+
+The CRM silent-shopper tracker is loaded on every page from `layout/theme.liquid`:
+
+```html
+<!-- A2 CRM Silent Shopper Tracker -->
+<script src="https://oryguntri.com/api/tracker/a2_tracker.js" defer></script>
+```
+
+That script defines the global we must call whenever we capture an email:
+
+```js
+window.a2_identify(email, source);   // e.g. ("rider@x.com", "exit_intent")
+```
+
+Server-side alternative: `POST https://oryguntri.com/api/identify`
+`{ "email": "...", "source": "...", "ga4_client_id": "...", "klaviyo_id": "..." }`
+→ always 204, no auth, idempotent per (person, source).
+
+**Exact source strings** (drive the per-source scoreboard at
+oryguntri.com/analytics): `exit_intent`, `fit_calculator`, `quiz`,
+`save_build`, `restock_alert`, `newsletter`, `chat`, `checkout`,
+`klaviyo_form` — or a new short snake_case name for a new mechanism.
+
+### Important: theme already has a *separate* helper — do not confuse them
+`layout/theme.liquid` also defines `window.a2IdentifyVisitor(email)`. That
+helper pushes to **Klaviyo / GA4 / Lucky Orange** but does **not** pass a
+`source` and does **not** hit the CRM's source-tagged identify. It also
+auto-identifies logged-in customers and re-fires from `sessionStorage`.
+
+**Every new capture must call BOTH:**
+1. `window.a2_identify(email, "<source>")` — CRM scoreboard (mandatory).
+2. `window.a2IdentifyVisitor(email)` — existing Klaviyo/GA4 identify (if present).
+
+---
+
+## Existing reusable patterns (in the live theme)
+
+- `assets/a2-lp.js` — shared LP behaviour. **Owns UTM/click-id capture**
+  (`sessionStorage["a2_attribution"]`, first-touch wins) and re-decorates
+  internal CTAs so attribution survives the click. Also a delegated Klaviyo
+  email-capture handler for `form[data-a2-klaviyo-form]`, a GTM `dataLayer`
+  helper exposed as `window.a2dl(event, extra)`, Octane quiz opener, Affirm
+  refresh. **Loaded per-LP-section, NOT globally** — a site-wide overlay can't
+  rely on it being present. **Never break the UTM capture behaviour.**
+- `snippets/a2-email-capture.liquid` — reusable Klaviyo capture form
+  (params: heading/text/cta/company_id/list_id/event/source/uid). Posts via
+  a2-lp.js. Reuse for newsletter/gate plays (play 4).
+- Klaviyo client subscription pattern (from a2-lp.js):
+  `POST https://a.klaviyo.com/client/subscriptions/?company_id=<id>`
+  header `revision: 2024-10-15`, body `{data:{type:"subscription",
+  attributes:{custom_source, profile:{data:{type:"profile",
+  attributes:{email, properties}}}}, relationships:{list:{data:{type:"list",
+  id:<list_id>}}}}}`.
+- Klaviyo company id: **`YejYTH`**. Per-flow list IDs are an owner decision —
+  set them in each section's settings.
+- Site-wide overlays render from `layout/theme.liquid` via
+  `{% sections 'overlay-group' %}` → `sections/overlay-group.json`. Add
+  global popups/modals there.
+- GTM owns GA4/Meta. Never hardcode pixels. Use `dataLayer` / `window.a2dl`.
+
+---
+
+## Deploy pipeline (hard rules)
+
+1. Edit source in this repo (`shopify/`) first; commit.
+2. Duplicate the current MAIN theme → a new **draft** (`themeDuplicate`).
+3. Upsert sections **before** the JSON templates/section-groups that use them.
+4. Verify `checksumMd5` on each upserted file against the local `md5`.
+5. Never publish; hand the preview link to the owner.
+
+---
+
+## Play tracker
+
+| # | Play | Source string | Status | Owner decisions blocking launch |
+|---|---|---|---|---|
+| 1 | Exit-intent capture (+ $X off) | `exit_intent` | **built + staged (disabled)** | discount **amount + code**, Klaviyo list id, final copy |
+| 2 | Email-gate Fit Calculator | `fit_calculator` | not started | **confirm current SP geometry (S/M/L/XL, not 2021 XS–L)** |
+| 3 | Save-your-build on PDPs | `save_build` | not started | — |
+| 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
+| 5 | Push the Octane quiz | `quiz` | not started | quiz placement prominence |
+| 6 | Back-in-stock / price-drop | `restock_alert` | not started | verify existing `snippets/a2-restock-alert.liquid` |
+| 7 | Sign in with Shop | `checkout` | not started | — |
+| 8 | Zoho chat asks email early | `chat` | not started | — |
+| 9 | Financing prequal step | `save_build`/new | not started | — |
+
+### Play 1 — exit-intent (this build)
+- `shopify/sections/a2-exit-intent.liquid` — self-contained global overlay
+  (own CSS+JS, does not depend on a2-lp.js). Added to `overlay-group.json`.
+- Ships **disabled by default** (`enable` setting off) and with a **blank
+  offer amount / code** so it cannot launch until the owner sets the figures
+  and flips it on — per the "figures live in settings, never hardcoded" rule.
+- On submit: `a2_identify(email,"exit_intent")` + `a2IdentifyVisitor(email)` +
+  Klaviyo subscription (custom_source `exit_intent`) + `dataLayer` event
+  `exit_intent_email_capture`, then reveals the discount code.

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -118,7 +118,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 3 | Save-your-build on PDPs | `save_build` | **built + staged** | needs a Klaviyo "Saved Build" flow + list to actually send the quote email |
 | 4 | Email flows as identity machines | `newsletter`/`klaviyo_form` | not started | Klaviyo flow coordination |
 | 5 | Push the Octane quiz | `quiz` | not started | quiz placement prominence |
-| 6 | Back-in-stock / price-drop | `restock_alert` | not started | verify existing `snippets/a2-restock-alert.liquid` |
+| 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
 | 7 | Sign in with Shop | `checkout` | not started | — |
 | 8 | Zoho chat asks email early | `chat` | not started | — |
 | 9 | Financing prequal step | `save_build`/new | not started | — |
@@ -171,6 +171,25 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   so the "check your inbox" promise is fulfilled. Set `sb_klaviyo_list` to that
   list. Note `A2_FIT_CTX.price` is the base product price; the emailed quote uses
   the live `[data-price]` DOM value scraped at submit.
+
+### Play 6 — back-in-stock / restock alert (this build)
+- Refreshed the existing SP "new colorway drop / notify me" card
+  `shopify/snippets/a2-restock-alert.liquid` (rendered on SP PDPs by
+  `sections/sppdp-product.liquid` only when `product.metafields.custom.restock_alert`
+  is true; that branch also loads `a2-lp.js`). Klaviyo company `YejYTH`, list
+  `TpVuRM` ("SP Drop — Notify Me").
+- **The gap fixed:** the card captured to Klaviyo (via a2-lp.js) + dataLayer but
+  never called the CRM. Added a scoped inline script: on submit it calls
+  `window.a2_identify(email, "restock_alert")` + `a2IdentifyVisitor` and persists
+  the email. a2-lp.js still owns the Klaviyo POST. Verbatim copy verified
+  byte-identical to live before the single append.
+- Staged to draft `176605397156`; checksum verified
+  `0d5848a1850eeec51b0e25637253c124`.
+- **Owner to-do:** set the `custom.restock_alert` boolean metafield on the SP
+  product(s) you want the card to appear on (it's per-product, owner-controlled).
+- **Follow-up (separate mechanism):** price-drop alerts. Not in this card; best
+  done via Klaviyo's native price-drop / a parallel "price drop" capture card
+  wired to a new `price_drop` source. Flagged, not built.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/docs/A2-VISITOR-ID-BUILD.md
+++ b/docs/A2-VISITOR-ID-BUILD.md
@@ -120,7 +120,7 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
 | 5 | Push the Octane quiz | `quiz` | **built + staged** | Octane app embed has a BLANK quiz id — confirm the quiz destination (page vs on-site) |
 | 6 | Back-in-stock (restock) | `restock_alert` | **built + staged** | set `custom.restock_alert` metafield on the SP product(s) to show it; price-drop is a separate follow-up |
 | 7 | Sign in with Shop | `account` | **theme wiring built + staged** | ENABLE Sign in with Shop in admin (Settings → Customer accounts) — owner action |
-| 8 | Zoho chat asks email early | `chat` | not started | — |
+| 8 | Zoho chat asks email early | `chat` | **theme capture built + staged** | Zoho dashboard: turn on pre-chat email field + (best) a webhook → oryguntri.com/api/identify |
 | 9 | Financing prequal step | `save_build`/new | not started | — |
 
 ### Shared staged draft theme
@@ -255,6 +255,21 @@ auto-identifies logged-in customers and re-fires from `sessionStorage`.
   cookied — the "email flows cookie the browser for ~2 years" mechanism. The
   remaining work is **Klaviyo flow coordination** (owner/Klaviyo side): make sure
   flows link back to the site so clicks re-identify returning browsers.
+
+### Play 8 — Zoho chat asks email early (this build)
+- Theme capture wired in `layout/theme.liquid`: the Zoho SalesIQ `ready` handler
+  now registers documented capture callbacks — `chat.continue`, `visitor.chat`,
+  `visitor.offlineMessage`, `visitor.feedback` — each in its own try/catch (so an
+  unsupported callback can never break the widget). On any of them it reads the
+  visitor email (callback payload, falling back to the `visitor.email()` getter)
+  and calls `a2_identify(email,"chat")` + `a2IdentifyVisitor`. Checksum
+  `fe8e22558ce07fcfc7ca0d3476fba911`; inline JS `node --check` clean.
+- **Owner actions (Zoho dashboard, external):** (1) turn on the **pre-chat form
+  email field** ("Where should we send the transcript?") so email is asked early;
+  (2) most reliable capture is a **Zoho webhook/integration → `POST
+  https://oryguntri.com/api/identify` `{email, source:"chat"}`** (server-side path
+  from the CRM contract) — the client-side hooks above are best-effort and depend
+  on which SalesIQ callbacks fire for your plan/config.
 
 ### Play 1 — exit-intent
 - Preview (same theme): `https://a2bikes.com/?preview_theme_id=176605397156`

--- a/shopify/assets/a2-lp.js
+++ b/shopify/assets/a2-lp.js
@@ -1,0 +1,263 @@
+/* ============================================================================
+   A2 Bikes — Landing Page core behaviour (shared, framework-free)
+   ----------------------------------------------------------------------------
+   Loaded once with `defer` by each A2 landing section. Re-execution is a no-op
+   (guarded below), so it is safe if multiple A2 sections appear on one page.
+
+   Responsibilities:
+     1. Capture + persist UTM / click-id attribution to sessionStorage and
+        re-append it to every internal CTA so attribution survives the click
+        into the PDP / checkout. (Attribution is currently broken on this store;
+        this keeps Google + Klaviyo traffic clean.)
+     2. Push GTM dataLayer events for every CTA click (GTM owns GA4 / Meta — we
+        never hardcode pixels here).
+     3. Handle email-capture forms -> Klaviyo client-side subscription API.
+     4. Open the Octane AI sizing quiz from a configurable trigger.
+     5. Refresh Affirm on-page messaging once it is available (non-blocking).
+
+   No third-party libraries. Nothing here is render-blocking.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  // Idempotency guard: if a second A2 section also injected this file, bail.
+  if (window.__a2lpInit) return;
+  window.__a2lpInit = true;
+
+  /* --- Attribution params we care about ----------------------------------- */
+  var TRACK_KEYS = [
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "utm_id", "gclid", "gbraid", "wbraid", "fbclid", "ttclid", "msclkid",
+    "_kx" // Klaviyo click identifier
+  ];
+  var STORE_KEY = "a2_attribution";
+
+  function readStore() {
+    try { return JSON.parse(sessionStorage.getItem(STORE_KEY)) || {}; }
+    catch (e) { return {}; }
+  }
+  function writeStore(obj) {
+    try { sessionStorage.setItem(STORE_KEY, JSON.stringify(obj)); } catch (e) {}
+  }
+
+  /* Capture params from the current URL, merging (not clobbering) what we have.
+     First-touch wins for a given key within the session. */
+  function captureAttribution() {
+    var params = new URLSearchParams(window.location.search);
+    var stored = readStore();
+    var changed = false;
+    TRACK_KEYS.forEach(function (k) {
+      var v = params.get(k);
+      if (v && !stored[k]) { stored[k] = v; changed = true; }
+    });
+    if (changed) writeStore(stored);
+    return stored;
+  }
+
+  /* Is this link internal (same origin / relative / Shopify route)? */
+  function isInternal(href) {
+    if (!href) return false;
+    if (href.charAt(0) === "/" || href.charAt(0) === "#") return true;
+    try { return new URL(href, window.location.origin).origin === window.location.origin; }
+    catch (e) { return false; }
+  }
+
+  /* Append stored attribution to an internal href without clobbering existing
+     query params already on the link. */
+  function decorate(href, attribution) {
+    if (!isInternal(href) || href.charAt(0) === "#") return href;
+    try {
+      var url = new URL(href, window.location.origin);
+      Object.keys(attribution).forEach(function (k) {
+        if (!url.searchParams.has(k)) url.searchParams.set(k, attribution[k]);
+      });
+      // Preserve relative form if the author wrote a relative link.
+      return /^https?:/i.test(href) ? url.toString() : url.pathname + url.search + url.hash;
+    } catch (e) { return href; }
+  }
+
+  /* --- GTM dataLayer helper ----------------------------------------------- */
+  function pushDL(event, extra) {
+    window.dataLayer = window.dataLayer || [];
+    var payload = { event: event };
+    var attribution = readStore();
+    Object.keys(attribution).forEach(function (k) { payload[k] = attribution[k]; });
+    if (extra) Object.keys(extra).forEach(function (k) { payload[k] = extra[k]; });
+    window.dataLayer.push(payload);
+  }
+  // Expose for inline/section use if ever needed.
+  window.a2dl = pushDL;
+
+  /* --- Wire CTA links ------------------------------------------------------ */
+  function decorateAllCtas(attribution) {
+    document.querySelectorAll("a[data-a2-cta]").forEach(function (a) {
+      var href = a.getAttribute("href");
+      a.setAttribute("href", decorate(href, attribution));
+    });
+  }
+
+  /* Delegated click handler: (re)decorate at click-time (covers async DOM and
+     params captured after initial paint) and fire the dataLayer event. */
+  function onClick(e) {
+    var el = e.target.closest("[data-a2-event], a[data-a2-cta]");
+    if (!el) return;
+
+    // Re-decorate the actual link being clicked, just before navigation.
+    if (el.matches("a[data-a2-cta]")) {
+      var href = el.getAttribute("href");
+      var dec = decorate(href, readStore());
+      if (dec !== href) el.setAttribute("href", dec);
+    }
+    var event = el.getAttribute("data-a2-event");
+    if (event) {
+      pushDL(event, {
+        cta_id: el.getAttribute("data-a2-cta-id") || null,
+        cta_text: (el.textContent || "").trim().slice(0, 80),
+        destination: el.getAttribute("href") || null
+      });
+    }
+  }
+
+  /* --- Octane AI sizing quiz ---------------------------------------------- */
+  function onOctane(e) {
+    var trigger = e.target.closest("[data-a2-octane]");
+    if (!trigger) return;
+    e.preventDefault();
+    var url = trigger.getAttribute("data-a2-octane-url");
+    pushDL("octane_quiz_open", { source: trigger.getAttribute("data-a2-source") || null });
+    // Prefer Octane's on-site JS API if present; otherwise open the quiz URL.
+    if (window.octaneai && typeof window.octaneai.open === "function") {
+      window.octaneai.open();
+    } else if (window.__octane && typeof window.__octane.openQuiz === "function") {
+      window.__octane.openQuiz();
+    } else if (url) {
+      window.open(decorate(url, readStore()), trigger.getAttribute("data-a2-target") || "_self");
+    } else {
+      console.warn("[a2-lp] Octane quiz trigger has no data-a2-octane-url and no Octane API present.");
+    }
+  }
+
+  /* --- Klaviyo email capture ---------------------------------------------- */
+  function emailMsg(form, state, text) {
+    var box = form.querySelector("[data-a2-msg]");
+    if (!box) return;
+    box.setAttribute("data-state", state);
+    box.textContent = text;
+  }
+
+  function onSubmit(e) {
+    var form = e.target.closest("form[data-a2-klaviyo-form]");
+    if (!form) return;
+    e.preventDefault();
+
+    // Honeypot: silently succeed for bots.
+    var hp = form.querySelector("[data-a2-hp]");
+    if (hp && hp.value) { emailMsg(form, "ok", form.getAttribute("data-a2-success") || "Thanks!"); return; }
+
+    var input = form.querySelector('input[type="email"]');
+    var email = (input && input.value || "").trim();
+    if (!email || email.indexOf("@") === -1) {
+      emailMsg(form, "error", "Please enter a valid email address.");
+      return;
+    }
+
+    var a2crmSource = form.getAttribute("data-a2-crm-source") || "newsletter";
+    try { if (typeof window.a2_identify === "function") window.a2_identify(email, a2crmSource); } catch(e){}
+
+    var company = form.getAttribute("data-a2-company");
+    var list = form.getAttribute("data-a2-list");
+    var source = form.getAttribute("data-a2-source") || "A2 Landing Page";
+    var event = form.getAttribute("data-a2-event") || "lp_email_capture";
+    var success = form.getAttribute("data-a2-success") || "You're in — check your inbox.";
+
+    // Always record intent for analytics, even before Klaviyo is configured.
+    pushDL(event, { email_domain: email.split("@")[1] || null, source: source });
+    emailMsg(form, "ok", "Sending…");
+
+    // If Klaviyo keys are not yet configured (draft/preview), show success UI
+    // but warn — no profile is actually created until keys are set.
+    if (!company || !list || /COMPANY_ID|LIST_ID/.test(company + list)) {
+      console.warn("[a2-lp] Klaviyo company_id/list_id not configured — email not sent to Klaviyo.");
+      emailMsg(form, "ok", success);
+      form.reset();
+      return;
+    }
+
+    // Optional profile properties. Two sources, merged:
+    //  1. data-a2-props on the form (static JSON) — e.g. which product.
+    //  2. any [data-a2-prop] field inside the form — the attr is the property
+    //     key, the field's value the value (radios/checkboxes only when
+    //     checked). Lets a form capture extra intent (e.g. size) without a
+    //     separate question. Absent/blank = plain email capture.
+    var profileAttrs = { email: email };
+    var props = {};
+    var propsRaw = form.getAttribute("data-a2-props");
+    if (propsRaw) {
+      try { props = JSON.parse(propsRaw) || {}; }
+      catch (e) { console.warn("[a2-lp] ignoring invalid data-a2-props JSON:", e); }
+    }
+    var propFields = form.querySelectorAll("[data-a2-prop]");
+    for (var pi = 0; pi < propFields.length; pi++) {
+      var pel = propFields[pi], pkey = pel.getAttribute("data-a2-prop");
+      if (!pkey) continue;
+      var ptype = (pel.type || "").toLowerCase();
+      if ((ptype === "radio" || ptype === "checkbox") && !pel.checked) continue;
+      var pval = (pel.value || "").trim();
+      if (pval) props[pkey] = pval;
+    }
+    if (Object.keys(props).length) profileAttrs.properties = props;
+
+    var body = {
+      data: {
+        type: "subscription",
+        attributes: {
+          custom_source: source,
+          profile: { data: { type: "profile", attributes: profileAttrs } }
+        },
+        relationships: { list: { data: { type: "list", id: list } } }
+      }
+    };
+
+    fetch("https://a.klaviyo.com/client/subscriptions/?company_id=" + encodeURIComponent(company), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", revision: "2024-10-15" },
+      body: JSON.stringify(body)
+    })
+      .then(function (res) {
+        if (res.status === 202 || res.ok) {
+          emailMsg(form, "ok", success);
+          form.reset();
+        } else {
+          emailMsg(form, "error", "Something went wrong — please try again.");
+        }
+      })
+      .catch(function () { emailMsg(form, "error", "Network error — please try again."); });
+  }
+
+  /* --- Affirm on-page messaging (non-blocking) ----------------------------- */
+  function refreshAffirm(tries) {
+    tries = tries || 0;
+    if (window.affirm && window.affirm.ui && typeof window.affirm.ui.refresh === "function") {
+      window.affirm.ui.refresh();
+    } else if (tries < 20) {
+      // Affirm.js may still be loading (it is async / store-wide). Poll briefly.
+      setTimeout(function () { refreshAffirm(tries + 1); }, 400);
+    }
+  }
+
+  /* --- Init ---------------------------------------------------------------- */
+  function init() {
+    var attribution = captureAttribution();
+    decorateAllCtas(attribution);
+    document.addEventListener("click", onClick, false);     // dataLayer + re-decorate
+    document.addEventListener("click", onOctane, false);    // sizing quiz
+    document.addEventListener("submit", onSubmit, false);   // email capture
+    refreshAffirm();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/shopify/layout/theme.liquid
+++ b/shopify/layout/theme.liquid
@@ -147,6 +147,7 @@
           var formData = e.detail.metaData;
           if (formData && formData.$email) {
             window.a2IdentifyVisitor(formData.$email);
+            try { if (typeof window.a2_identify === 'function') window.a2_identify(formData.$email, 'klaviyo_form'); } catch(e){}
           }
         }
       });
@@ -163,6 +164,11 @@
             var emailInput = form.querySelector('input[type="email"]');
             if (emailInput && emailInput.value) {
               window.a2IdentifyVisitor(emailInput.value);
+              // CRM scoreboard source: Shopify newsletter + contact forms both POST to
+              // /contact, so use form_type ("contact" => contact-us, else newsletter).
+              var _ft = (form.querySelector('input[name="form_type"]') || {}).value || '';
+              var _src = _ft === 'contact' ? 'contact' : 'newsletter';
+              try { if (typeof window.a2_identify === 'function') window.a2_identify(emailInput.value, _src); } catch(e){}
             }
           });
         });

--- a/shopify/layout/theme.liquid
+++ b/shopify/layout/theme.liquid
@@ -126,9 +126,11 @@
         } catch(e) {}
       };
 
-      // Auto-identify if Shopify customer is logged in
+      // Auto-identify if Shopify customer is logged in (incl. Sign in with Shop /
+      // Shop Pay returners): also tag the CRM scoreboard with source "account".
       {% if customer %}
         window.a2IdentifyVisitor("{{ customer.email }}");
+        try { if (typeof window.a2_identify === 'function') window.a2_identify("{{ customer.email }}", "account"); } catch(e){}
       {% endif %}
 
       // Auto-identify if email in sessionStorage from prior page

--- a/shopify/layout/theme.liquid
+++ b/shopify/layout/theme.liquid
@@ -239,7 +239,25 @@
     {{ '//cdn.shopify.com/shopifycloud/shopify-plyr/v1.0/shopify-plyr.css' | stylesheet_tag }}
     <script>
       window.$zoho = window.$zoho || {};
-      $zoho.salesiq = $zoho.salesiq || { ready: function () {} };
+      $zoho.salesiq = $zoho.salesiq || {};
+      // A2 CRM: when a visitor gives their email in chat, tag them as source "chat".
+      // Registers documented SalesIQ capture callbacks defensively (try/catch each,
+      // so an unsupported one can never break the widget). Email read from the
+      // callback payload, falling back to the visitor.email() getter.
+      $zoho.salesiq.ready = function () {
+        function a2cap(email) {
+          if (!email) return;
+          email = String(email).toLowerCase().trim();
+          if (email.indexOf("@") < 1) return;
+          try { if (typeof window.a2_identify === "function") window.a2_identify(email, "chat"); } catch (e) {}
+          try { if (typeof window.a2IdentifyVisitor === "function") window.a2IdentifyVisitor(email); } catch (e) {}
+        }
+        function a2apiEmail() { try { return $zoho.salesiq.visitor.email(); } catch (e) { return ""; } }
+        try { $zoho.salesiq.chat.continue(function (v, d) { a2cap((d && d.visitoremail) || a2apiEmail()); }); } catch (e) {}
+        try { $zoho.salesiq.visitor.chat(function (d) { a2cap((d && (d.email || d.visitoremail)) || a2apiEmail()); }); } catch (e) {}
+        try { $zoho.salesiq.visitor.offlineMessage(function (d) { a2cap((d && (d.email || d.visitoremail)) || a2apiEmail()); }); } catch (e) {}
+        try { $zoho.salesiq.visitor.feedback(function (d) { a2cap((d && (d.email || d.visitoremail)) || a2apiEmail()); }); } catch (e) {}
+      };
     </script>
     <script
       id="zsiqscript"

--- a/shopify/layout/theme.liquid
+++ b/shopify/layout/theme.liquid
@@ -1,0 +1,252 @@
+<!doctype html>
+
+<!--
+  ___                 ___           ___           ___
+       /  /\                     /__/\         /  /\         /  /\
+      /  /:/_                    \  \:\       /  /:/        /  /::\
+     /  /:/ /\  ___     ___       \  \:\     /  /:/        /  /:/\:\
+    /  /:/ /:/ /__/\   /  /\  ___  \  \:\   /  /:/  ___   /  /:/  \:\
+   /__/:/ /:/  \  \:\ /  /:/ /__/\  \__\:\ /__/:/  /  /\ /__/:/ \__\:\
+   \  \:\/:/    \  \:\  /:/  \  \:\ /  /:/ \  \:\ /  /:/ \  \:\ /  /:/
+    \  \::/      \  \:\/:/    \  \:\  /:/   \  \:\  /:/   \  \:\  /:/
+     \  \:\       \  \::/      \  \:\/:/     \  \:\/:/     \  \:\/:/
+      \  \:\       \__\/        \  \::/       \  \::/       \  \::/
+       \__\/                     \__\/         \__\/         \__\/
+
+  --------------------------------------------------------------------
+  #  Stiletto v5.2.2
+  #  Documentation: https://help.fluorescent.co/v/stiletto
+  #  Purchase: https://themes.shopify.com/themes/stiletto/
+  #  A product by Fluorescent: https://fluorescent.co/
+  --------------------------------------------------------------------
+-->
+
+<html
+  class="no-js"
+  lang="{{ request.locale.iso_code }}"
+  style="
+    --announcement-height: 1px;
+    --mobile-sticky-header-height: 0px;
+    --mobile-sticky-announcement-height: 0px;
+  "
+>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    {% render 'meta-description' %}
+
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
+    {%- comment -%} CWV: warm up connections to render-relevant third-party origins. {%- endcomment -%}
+    <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
+    <link rel="dns-prefetch" href="https://static.klaviyo.com">
+    <link rel="dns-prefetch" href="https://cdn1.affirm.com">
+
+    {%- if settings.favicon != blank -%}
+      <link rel="shortcut icon" href="{{ settings.favicon | image_url: width: 32, height: 32 }}" type="image/png">
+    {%- endif -%}
+
+    {%- capture seo_title -%}
+      {%- if request.page_type == 'search' and search.performed == true -%}
+        {{ 'search.heading' | t: count: search.results_count }}:
+        {{ 'search.results_with_count' | t: terms: search.terms, count: search.results_count }}
+      {%- else -%}
+        {{ page_title }}
+      {%- endif -%}
+      {%- if current_tags -%}
+        {%- assign meta_tags = current_tags | join: ', ' -%}
+        &ndash; {{ 'general.meta.tags' | t: tags: meta_tags -}}
+      {%- endif -%}
+      {%- if current_page != 1 -%}
+        &ndash; {{ 'general.meta.page' | t: page: current_page }}
+      {%- endif -%}
+      {%- assign escaped_page_title = page_title | escape -%}
+      {%- unless escaped_page_title contains shop.name -%}
+        &ndash; {{ shop.name }}
+      {%- endunless -%}
+    {%- endcapture -%}
+    <title>{{ seo_title | strip }}</title>
+
+    {% render 'social-meta-tags' %}
+
+    {% render 'theme-setup' %}
+    {% render 'theme-setting-vars' %}
+    {%- render 'theme-globals' -%}
+
+    {{ content_for_header }}
+
+
+    <!-- Google Analytics 4
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-W2Q749NZM8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-W2Q749NZM8'{% if customer %}, {
+        'user_id': '{{ customer.id }}'
+      }{% endif %});
+    </script>  -->
+
+
+    <script>
+      window.a2IdentifyVisitor = function(email) {
+        if (!email || email.indexOf("@") === -1) return;
+        email = email.toLowerCase().trim();
+
+        // 1. Klaviyo identify
+        if (window._learnq) {
+          window._learnq.push(["identify", {
+            "$email": email
+          }]);
+        }
+
+        // 2. GA4 User-ID and custom dimension
+        if (typeof gtag === 'function') {
+          gtag("set", "user_properties", {
+            "customer_email": email
+          });
+          gtag("event", "user_identified", {
+            "method": "email_capture",
+            "customer_email": email
+          });
+        }
+
+        // 3. Lucky Orange identify (no-op unless the Lucky Orange embed is enabled)
+        if (window.LO && window.LO.visitor) {
+          window.LO.visitor.identify(email, {
+            name: email.split("@")[0]
+          });
+        }
+
+        // 4. Store for later use
+        try {
+          sessionStorage.setItem("a2_visitor_email", email);
+        } catch(e) {}
+      };
+
+      // Auto-identify if Shopify customer is logged in
+      {% if customer %}
+        window.a2IdentifyVisitor("{{ customer.email }}");
+      {% endif %}
+
+      // Auto-identify if email in sessionStorage from prior page
+      try {
+        var storedEmail = sessionStorage.getItem("a2_visitor_email");
+        if (storedEmail) { window.a2IdentifyVisitor(storedEmail); }
+      } catch(e) {}
+    </script>
+
+    <script>
+      // Listen for Klaviyo form submissions (popup, embedded forms)
+      window.addEventListener('klaviyoForms', function (e) {
+        if (e.detail.type === 'submit' || e.detail.type === 'redirectedToUrl') {
+          var formData = e.detail.metaData;
+          if (formData && formData.$email) {
+            window.a2IdentifyVisitor(formData.$email);
+          }
+        }
+      });
+    </script>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        // Hook into newsletter/contact forms
+        var forms = document.querySelectorAll(
+          'form[action*="subscribe"], form.newsletter-form, form[action*="/contact"]'
+        );
+        forms.forEach(function (form) {
+          form.addEventListener('submit', function () {
+            var emailInput = form.querySelector('input[type="email"]');
+            if (emailInput && emailInput.value) {
+              window.a2IdentifyVisitor(emailInput.value);
+            }
+          });
+        });
+      });
+    </script>
+
+    <script>
+      // Listen for Octane AI quiz completions
+      window.addEventListener('message', function (event) {
+        try {
+          var data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+          if (data && data.type === 'octane-quiz-completed' && data.email) {
+            window.a2IdentifyVisitor(data.email);
+            try { if (typeof window.a2_identify === 'function') window.a2_identify(data.email, 'quiz'); } catch(e){}
+          }
+          if (data && data.octaneai && data.octaneai.email) {
+            window.a2IdentifyVisitor(data.octaneai.email);
+            try { if (typeof window.a2_identify === 'function') window.a2_identify(data.octaneai.email, 'quiz'); } catch(e){}
+          }
+        } catch (e) {}
+      });
+    </script>
+  {%- comment -%}
+  Disabled May 2026 — A2 CRM (OrygunTri) under development.
+  Re-enable when ops/dev team confirms ready.
+  Original tag:
+  <script async defer
+      src="https://oryguntri.com/api/tracker/a2_tracker.js"
+      onerror="console.warn('A2 tracker unavailable')"></script>
+{%- endcomment -%}
+  </head>
+
+  <body class="template-{{ request.page_type | handle }}">
+
+    <div class="page">
+      {% if settings.enable_page_transitions %}
+        {% render 'page-transition-overlay' %}
+      {% endif %}
+
+      <div class="theme-editor-scroll-offset"></div>
+
+      <div class="header__space" data-header-space></div>
+
+      {% sections 'header-group' %}
+      {% sections 'overlay-group' %}
+
+      {%- if settings.enable_quick_search -%}
+        {% render 'quick-search' %}
+      {%- endif -%}
+
+      <div class="header-overlay" data-header-overlay>
+        <div class="header-overlay__inner"></div>
+      </div>
+
+      <main id="main" class="main">
+        {{ content_for_layout }}
+      </main>
+
+      {% sections 'footer-group' %}
+
+      {% render 'store-availability-drawer' %}
+      {% render 'quick-view-modal' %}
+      {% render 'modal' %}
+      {% render 'back-to-top' %}
+    </div>
+
+    {{ '//www.youtube.com/iframe_api' | script_tag }}
+    {{ '//cdn.shopify.com/shopifycloud/shopify-plyr/v1.0/shopify-plyr.css' | stylesheet_tag }}
+    <script>
+      window.$zoho = window.$zoho || {};
+      $zoho.salesiq = $zoho.salesiq || { ready: function () {} };
+    </script>
+    <script
+      id="zsiqscript"
+      src="https://salesiq.zohopublic.com/widget?wc=siq1dac5c1474961a477a196d6e8d708f423d02987807286b02d63de9453f90c112"
+      defer
+    ></script>
+  <!-- A2 CRM Silent Shopper Tracker -->
+<script src="https://oryguntri.com/api/tracker/a2_tracker.js" defer></script>
+  </body>
+  <link
+    rel="preload"
+    fetchpriority="low"
+    href="{{ 'theme-deferred.css' | asset_url }}"
+    as="style"
+    onload="this.onload=null;this.rel='stylesheet'"
+  >
+  <noscript><link rel="stylesheet" href="{{ 'theme-deferred.css' | asset_url }}"></noscript>
+</html>

--- a/shopify/sections/a2-exit-intent.liquid
+++ b/shopify/sections/a2-exit-intent.liquid
@@ -1,0 +1,431 @@
+{%- comment -%}
+  A2 Bikes — Play 1: Exit-intent email capture with a bike-sized offer.
+  ---------------------------------------------------------------------------
+  Global overlay (mount in overlay-group so it renders on every page). On exit
+  intent it offers "Save your build + $X off your first bike" in exchange for an
+  email, then reveals the discount code.
+
+  Identity wiring (the whole point):
+    - window.a2_identify(email, "exit_intent")   -> CRM scoreboard (mandatory)
+    - window.a2IdentifyVisitor(email)            -> existing Klaviyo/GA4 helper
+    - Klaviyo client subscription (custom_source "exit_intent") if keys are set
+    - dataLayer event "exit_intent_email_capture" (GTM owns GA4/Meta)
+
+  Safety rails:
+    - Ships DISABLED (settings.enable off) and with a BLANK offer amount/code.
+      It cannot show until the owner sets the figures AND enables it.
+    - All offer figures + Klaviyo ids live in settings, never hardcoded.
+    - Self-contained: does not depend on a2-lp.js being on the page.
+{%- endcomment -%}
+
+{%- liquid
+  assign en = section.settings.enable
+  assign amount = section.settings.offer_amount | strip
+  assign code = section.settings.discount_code | strip
+  assign company = section.settings.klaviyo_company_id | strip
+  assign list_id = section.settings.klaviyo_list_id | strip
+-%}
+
+{%- if en and amount != blank -%}
+<div
+  id="a2ei-{{ section.id }}"
+  class="a2ei"
+  data-a2ei
+  data-freq-days="{{ section.settings.frequency_days }}"
+  data-mobile-trigger="{{ section.settings.mobile_trigger }}"
+  data-mobile-delay="{{ section.settings.mobile_delay_seconds }}"
+  data-exclude-accounts="{% if section.settings.hide_for_accounts %}1{% else %}0{% endif %}"
+  data-code="{{ code | escape }}"
+  data-company="{{ company | escape }}"
+  data-list="{{ list_id | escape }}"
+  data-source="exit_intent"
+  {% if customer %}data-logged-in="1"{% endif %}
+  hidden
+>
+  <div class="a2ei__overlay" data-a2ei-dismiss></div>
+  <div class="a2ei__dialog" role="dialog" aria-modal="true"
+       aria-labelledby="a2ei-title-{{ section.id }}" tabindex="-1">
+    <button type="button" class="a2ei__close" data-a2ei-dismiss aria-label="Close">&times;</button>
+
+    {%- if section.settings.image != blank -%}
+      <div class="a2ei__media">
+        {{ section.settings.image | image_url: width: 900 | image_tag:
+           loading: 'lazy', widths: '360,600,900', alt: section.settings.heading | escape }}
+      </div>
+    {%- endif -%}
+
+    <div class="a2ei__body">
+      {%- if section.settings.eyebrow != blank -%}
+        <p class="a2ei__eyebrow">{{ section.settings.eyebrow }}</p>
+      {%- endif -%}
+
+      {%- comment -%} ---- Capture state ---- {%- endcomment -%}
+      <div data-a2ei-step="capture">
+        <h2 class="a2ei__title" id="a2ei-title-{{ section.id }}">
+          {{ section.settings.heading | replace: '[amount]', amount }}
+        </h2>
+        {%- if section.settings.subheading != blank -%}
+          <p class="a2ei__sub">{{ section.settings.subheading | replace: '[amount]', amount }}</p>
+        {%- endif -%}
+
+        <form class="a2ei__form" data-a2ei-form novalidate>
+          <label class="a2ei__sronly" for="a2ei-email-{{ section.id }}">Email address</label>
+          <input id="a2ei-email-{{ section.id }}" class="a2ei__input" type="email" name="email"
+                 required autocomplete="email" inputmode="email"
+                 placeholder="{{ section.settings.placeholder | default: 'you@email.com' | escape }}">
+          {%- comment -%} Honeypot: bots fill it, humans don't. {%- endcomment -%}
+          <div class="a2ei__hp" aria-hidden="true">
+            <label>Leave blank<input type="text" tabindex="-1" autocomplete="off" data-a2ei-hp></label>
+          </div>
+          <button class="a2ei__cta" type="submit">
+            {{ section.settings.cta_label | default: 'Email my build & unlock my discount' | replace: '[amount]', amount }}
+          </button>
+          <p class="a2ei__msg" data-a2ei-msg role="status" aria-live="polite"></p>
+        </form>
+
+        <button type="button" class="a2ei__decline" data-a2ei-dismiss>
+          {{ section.settings.dismiss_text | default: 'No thanks, I’ll pay full price' }}
+        </button>
+      </div>
+
+      {%- comment -%} ---- Success state ---- {%- endcomment -%}
+      <div data-a2ei-step="success" hidden>
+        <h2 class="a2ei__title">{{ section.settings.success_heading | default: 'You’re in — here’s your code' | replace: '[amount]', amount }}</h2>
+        <p class="a2ei__sub">{{ section.settings.success_text | default: 'Use this code at checkout for [amount] off your first bike.' | replace: '[amount]', amount }}</p>
+        {%- if code != blank -%}
+          <div class="a2ei__code">
+            <span data-a2ei-code>{{ code }}</span>
+            <button type="button" class="a2ei__copy" data-a2ei-copy aria-label="Copy code">Copy</button>
+          </div>
+        {%- endif -%}
+        {%- if section.settings.success_cta_url != blank -%}
+          <a class="a2ei__cta a2ei__cta--link" href="{{ section.settings.success_cta_url }}">
+            {{ section.settings.success_cta_label | default: 'Keep building' }}
+          </a>
+        {%- endif -%}
+      </div>
+
+      {%- if section.settings.disclaimer != blank -%}
+        <p class="a2ei__fine">{{ section.settings.disclaimer }}</p>
+      {%- endif -%}
+    </div>
+  </div>
+</div>
+
+{%- style -%}
+  #a2ei-{{ section.id }}.a2ei{position:fixed;inset:0;z-index:2147483000;display:none;}
+  #a2ei-{{ section.id }}.a2ei.is-open{display:block;}
+  #a2ei-{{ section.id }} .a2ei__overlay{position:absolute;inset:0;background:rgba(0,0,0,.62);}
+  #a2ei-{{ section.id }} .a2ei__dialog{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(560px,calc(100vw - 32px));max-height:calc(100vh - 32px);overflow:auto;
+    background:{{ section.settings.bg_color }};color:{{ section.settings.text_color }};
+    border-radius:14px;box-shadow:0 24px 70px rgba(0,0,0,.35);}
+  #a2ei-{{ section.id }} .a2ei__close{position:absolute;top:8px;right:12px;background:none;border:0;
+    font-size:30px;line-height:1;color:inherit;opacity:.6;cursor:pointer;z-index:2;}
+  #a2ei-{{ section.id }} .a2ei__close:hover{opacity:1;}
+  #a2ei-{{ section.id }} .a2ei__media img{display:block;width:100%;height:auto;border-radius:14px 14px 0 0;}
+  #a2ei-{{ section.id }} .a2ei__body{padding:28px 28px 24px;}
+  #a2ei-{{ section.id }} .a2ei__eyebrow{margin:0 0 6px;font-size:12px;letter-spacing:.12em;
+    text-transform:uppercase;opacity:.7;font-weight:700;}
+  #a2ei-{{ section.id }} .a2ei__title{margin:0 0 8px;font-size:26px;line-height:1.15;font-weight:800;}
+  #a2ei-{{ section.id }} .a2ei__sub{margin:0 0 18px;font-size:16px;line-height:1.45;opacity:.9;}
+  #a2ei-{{ section.id }} .a2ei__form{display:flex;flex-direction:column;gap:10px;}
+  #a2ei-{{ section.id }} .a2ei__input{width:100%;padding:14px 16px;font-size:16px;border-radius:10px;
+    border:1px solid rgba(0,0,0,.25);background:#fff;color:#111;box-sizing:border-box;}
+  #a2ei-{{ section.id }} .a2ei__cta{width:100%;padding:15px 18px;font-size:16px;font-weight:700;
+    border:0;border-radius:10px;cursor:pointer;background:{{ section.settings.button_bg }};
+    color:{{ section.settings.button_text }};text-align:center;text-decoration:none;display:block;box-sizing:border-box;}
+  #a2ei-{{ section.id }} .a2ei__cta:hover{opacity:.92;}
+  #a2ei-{{ section.id }} .a2ei__cta--link{margin-top:14px;}
+  #a2ei-{{ section.id }} .a2ei__decline{display:block;margin:14px auto 0;background:none;border:0;
+    font-size:13px;text-decoration:underline;opacity:.65;color:inherit;cursor:pointer;}
+  #a2ei-{{ section.id }} .a2ei__decline:hover{opacity:1;}
+  #a2ei-{{ section.id }} .a2ei__msg{margin:4px 0 0;font-size:14px;min-height:1em;}
+  #a2ei-{{ section.id }} .a2ei__msg[data-state="error"]{color:#c0392b;}
+  #a2ei-{{ section.id }} .a2ei__msg[data-state="ok"]{color:#1e7e34;}
+  #a2ei-{{ section.id }} .a2ei__code{display:flex;align-items:center;gap:12px;margin:6px 0 4px;
+    padding:14px 16px;border:2px dashed rgba(0,0,0,.3);border-radius:10px;
+    font-size:22px;font-weight:800;letter-spacing:.06em;justify-content:space-between;}
+  #a2ei-{{ section.id }} .a2ei__copy{border:0;border-radius:8px;padding:8px 14px;font-size:13px;
+    font-weight:700;cursor:pointer;background:{{ section.settings.button_bg }};color:{{ section.settings.button_text }};}
+  #a2ei-{{ section.id }} .a2ei__fine{margin:16px 0 0;font-size:11px;line-height:1.4;opacity:.6;}
+  #a2ei-{{ section.id }} .a2ei__hp{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;}
+  #a2ei-{{ section.id }} .a2ei__sronly{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);}
+  @media (max-width:600px){
+    #a2ei-{{ section.id }} .a2ei__dialog{width:100vw;max-width:100vw;left:0;top:auto;bottom:0;
+      transform:none;border-radius:16px 16px 0 0;max-height:92vh;}
+    #a2ei-{{ section.id }} .a2ei__media img{border-radius:16px 16px 0 0;}
+    #a2ei-{{ section.id }} .a2ei__title{font-size:22px;}
+    #a2ei-{{ section.id }} .a2ei__body{padding:22px 20px 20px;}
+  }
+  @media (prefers-reduced-motion:no-preference){
+    #a2ei-{{ section.id }}.is-open .a2ei__dialog{animation:a2eiIn .22s ease-out;}
+    @keyframes a2eiIn{from{opacity:0;transform:translate(-50%,-46%);}to{opacity:1;transform:translate(-50%,-50%);}}
+  }
+{%- endstyle -%}
+
+<script>
+(function(){
+  var root = document.getElementById("a2ei-{{ section.id }}");
+  if (!root || root.__a2eiInit) return;
+  root.__a2eiInit = true;
+
+  // In the theme editor, let the merchant preview without trigger/frequency logic.
+  var isEditor = window.Shopify && Shopify.designMode;
+
+  var freqDays = parseInt(root.getAttribute("data-freq-days"), 10) || 7;
+  var STORE_KEY = "a2ei_last_shown";
+  var dialog   = root.querySelector(".a2ei__dialog");
+  var form     = root.querySelector("[data-a2ei-form]");
+  var msgBox   = root.querySelector("[data-a2ei-msg]");
+  var stepCap  = root.querySelector('[data-a2ei-step="capture"]');
+  var stepOk   = root.querySelector('[data-a2ei-step="success"]');
+  var lastFocus = null;
+  var shownThisPage = false;
+
+  function alreadyIdentified(){
+    try { if (sessionStorage.getItem("a2_visitor_email")) return true; } catch(e){}
+    if (root.getAttribute("data-logged-in") === "1" &&
+        root.getAttribute("data-exclude-accounts") === "1") return true;
+    return false;
+  }
+  function recentlyShown(){
+    if (isEditor) return false;
+    try {
+      var t = parseInt(localStorage.getItem(STORE_KEY), 10);
+      if (!t) return false;
+      return (Date.now() - t) < freqDays * 864e5;
+    } catch(e){ return false; }
+  }
+  function markShown(){ try { localStorage.setItem(STORE_KEY, String(Date.now())); } catch(e){} }
+
+  function onCheckoutOrCart(){
+    var p = location.pathname;
+    return /\/(checkouts|cart)(\/|$)/.test(p);
+  }
+
+  function pushDL(evt, extra){
+    var payload = { event: evt };
+    if (extra) Object.keys(extra).forEach(function(k){ payload[k] = extra[k]; });
+    if (typeof window.a2dl === "function") { window.a2dl(evt, extra || {}); return; }
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(payload);
+  }
+
+  function open(){
+    if (root.classList.contains("is-open")) return;
+    lastFocus = document.activeElement;
+    root.hidden = false;
+    root.classList.add("is-open");
+    markShown();
+    shownThisPage = true;
+    pushDL("exit_intent_shown", { source: "exit_intent" });
+    if (dialog) dialog.focus();
+    document.addEventListener("keydown", onKey);
+  }
+  function close(){
+    root.classList.remove("is-open");
+    root.hidden = true;
+    document.removeEventListener("keydown", onKey);
+    if (lastFocus && lastFocus.focus) { try { lastFocus.focus(); } catch(e){} }
+  }
+  function onKey(e){
+    if (e.key === "Escape") close();
+  }
+
+  function canShow(){
+    if (isEditor) return true;
+    return !shownThisPage && !alreadyIdentified() && !recentlyShown() && !onCheckoutOrCart();
+  }
+  function maybeOpen(){ if (canShow()) open(); }
+
+  /* ---- Triggers ---- */
+  // Desktop: pointer leaves through the top of the viewport.
+  document.addEventListener("mouseout", function(e){
+    if (e.clientY <= 0 && !e.relatedTarget && !e.toElement) maybeOpen();
+  });
+
+  // Mobile: no real exit intent. Configurable fallback.
+  var mTrigger = root.getAttribute("data-mobile-trigger") || "scroll_up";
+  var isTouch = matchMedia("(max-width: 600px), (pointer: coarse)").matches;
+  if (isTouch && !isEditor) {
+    if (mTrigger === "timer") {
+      var delay = (parseInt(root.getAttribute("data-mobile-delay"), 10) || 25) * 1000;
+      setTimeout(maybeOpen, delay);
+    } else if (mTrigger === "scroll_up") {
+      // Fire on a decisive upward scroll after the user has gone deep — a
+      // common proxy for "heading for the back button / address bar".
+      var lastY = window.pageYOffset, deepReached = false;
+      window.addEventListener("scroll", function(){
+        var y = window.pageYOffset;
+        var docH = document.documentElement.scrollHeight - window.innerHeight;
+        if (docH > 0 && y / docH > 0.5) deepReached = true;
+        if (deepReached && lastY - y > 90) maybeOpen();
+        lastY = y;
+      }, { passive: true });
+    }
+  }
+
+  /* ---- Dismiss wiring ---- */
+  root.querySelectorAll("[data-a2ei-dismiss]").forEach(function(el){
+    el.addEventListener("click", function(e){ e.preventDefault(); close(); });
+  });
+
+  /* ---- Copy code ---- */
+  var copyBtn = root.querySelector("[data-a2ei-copy]");
+  if (copyBtn) {
+    copyBtn.addEventListener("click", function(){
+      var code = root.getAttribute("data-code") || "";
+      if (navigator.clipboard && code) {
+        navigator.clipboard.writeText(code).then(function(){
+          copyBtn.textContent = "Copied";
+          setTimeout(function(){ copyBtn.textContent = "Copy"; }, 2000);
+        }).catch(function(){});
+      }
+    });
+  }
+
+  /* ---- Submit ---- */
+  function setMsg(state, text){
+    if (!msgBox) return;
+    msgBox.setAttribute("data-state", state);
+    msgBox.textContent = text;
+  }
+
+  function subscribeKlaviyo(email){
+    var company = root.getAttribute("data-company");
+    var list = root.getAttribute("data-list");
+    if (!company || !list) return; // not configured yet — CRM identify still fired
+    var body = {
+      data: {
+        type: "subscription",
+        attributes: {
+          custom_source: "exit_intent",
+          profile: { data: { type: "profile", attributes: { email: email,
+            properties: { a2_capture_source: "exit_intent" } } } }
+        },
+        relationships: { list: { data: { type: "list", id: list } } }
+      }
+    };
+    try {
+      fetch("https://a.klaviyo.com/client/subscriptions/?company_id=" + encodeURIComponent(company), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", revision: "2024-10-15" },
+        body: JSON.stringify(body)
+      }).catch(function(){});
+    } catch(e){}
+  }
+
+  function identify(email){
+    // 1. CRM scoreboard — mandatory, exact source string.
+    try { if (typeof window.a2_identify === "function") window.a2_identify(email, "exit_intent"); } catch(e){}
+    // 2. Existing Klaviyo/GA4 helper (theme.liquid), if present.
+    try { if (typeof window.a2IdentifyVisitor === "function") window.a2IdentifyVisitor(email); } catch(e){}
+    // 3. Persist so later pages auto-identify.
+    try { sessionStorage.setItem("a2_visitor_email", email); } catch(e){}
+    // 4. Direct Klaviyo subscription (feeds the $X-off email flow).
+    subscribeKlaviyo(email);
+  }
+
+  if (form) {
+    form.addEventListener("submit", function(e){
+      e.preventDefault();
+      var hp = form.querySelector("[data-a2ei-hp]");
+      if (hp && hp.value) { showSuccess(); return; } // silent bot pass
+      var input = form.querySelector('input[type="email"]');
+      var email = (input && input.value || "").trim().toLowerCase();
+      if (!email || email.indexOf("@") < 1) { setMsg("error", "Please enter a valid email address."); return; }
+      setMsg("ok", "Unlocking…");
+      identify(email);
+      pushDL("exit_intent_email_capture", { source: "exit_intent", email_domain: email.split("@")[1] || null });
+      showSuccess();
+    });
+  }
+
+  function showSuccess(){
+    if (stepCap) stepCap.hidden = true;
+    if (stepOk) stepOk.hidden = false;
+  }
+})();
+</script>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "A2 Exit-Intent Offer",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Launch"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable",
+      "label": "Enable exit-intent popup",
+      "default": false,
+      "info": "Keep OFF until the discount amount + code are confirmed with the owner. The popup will not render while this is off."
+    },
+    {
+      "type": "text",
+      "id": "offer_amount",
+      "label": "Offer amount (OWNER DECISION)",
+      "info": "e.g. \"$100\". The popup will not render until this is set. Used wherever [amount] appears in the copy below."
+    },
+    {
+      "type": "text",
+      "id": "discount_code",
+      "label": "Discount code (OWNER DECISION)",
+      "info": "The real code shown on success. Create it in Shopify Admin › Discounts first."
+    },
+    {
+      "type": "header",
+      "content": "Copy"
+    },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "Before you go" },
+    { "type": "text", "id": "heading", "label": "Heading", "default": "Save your build + get [amount] off your first bike" },
+    { "type": "textarea", "id": "subheading", "label": "Subheading", "default": "We’ll email your configuration so you can pick up right where you left off — and take [amount] off when you’re ready." },
+    { "type": "text", "id": "placeholder", "label": "Input placeholder", "default": "you@email.com" },
+    { "type": "text", "id": "cta_label", "label": "Button label", "default": "Email my build & unlock [amount] off" },
+    { "type": "text", "id": "dismiss_text", "label": "Decline link", "default": "No thanks, I’ll pay full price" },
+    { "type": "text", "id": "success_heading", "label": "Success heading", "default": "You’re in — here’s your code" },
+    { "type": "textarea", "id": "success_text", "label": "Success text", "default": "Use this code at checkout for [amount] off your first bike. We’ve emailed it to you too." },
+    { "type": "text", "id": "success_cta_label", "label": "Success button label", "default": "Keep building" },
+    { "type": "url", "id": "success_cta_url", "label": "Success button link" },
+    { "type": "textarea", "id": "disclaimer", "label": "Fine print", "default": "One use per customer. Valid on your first bike. Terms apply." },
+    {
+      "type": "header",
+      "content": "Klaviyo (feeds the offer email flow)"
+    },
+    { "type": "text", "id": "klaviyo_company_id", "label": "Klaviyo company ID", "default": "YejYTH" },
+    { "type": "text", "id": "klaviyo_list_id", "label": "Klaviyo list ID (OWNER DECISION)", "info": "List that the exit-intent / $X-off flow listens on. Leave blank to capture to the CRM only." },
+    {
+      "type": "header",
+      "content": "Trigger & frequency"
+    },
+    { "type": "range", "id": "frequency_days", "label": "Don’t show again for (days)", "min": 1, "max": 60, "step": 1, "default": 7 },
+    {
+      "type": "select",
+      "id": "mobile_trigger",
+      "label": "Mobile trigger",
+      "options": [
+        { "value": "scroll_up", "label": "Fast scroll-up after scrolling deep" },
+        { "value": "timer", "label": "After a delay" },
+        { "value": "off", "label": "Off (desktop only)" }
+      ],
+      "default": "scroll_up"
+    },
+    { "type": "range", "id": "mobile_delay_seconds", "label": "Mobile delay (seconds)", "min": 5, "max": 120, "step": 5, "default": 25, "info": "Only used when Mobile trigger = After a delay." },
+    { "type": "checkbox", "id": "hide_for_accounts", "label": "Hide for logged-in customers", "default": true },
+    {
+      "type": "header",
+      "content": "Style"
+    },
+    { "type": "image_picker", "id": "image", "label": "Image (optional)" },
+    { "type": "color", "id": "bg_color", "label": "Background", "default": "#ffffff" },
+    { "type": "color", "id": "text_color", "label": "Text", "default": "#111111" },
+    { "type": "color", "id": "button_bg", "label": "Button background", "default": "#111111" },
+    { "type": "color", "id": "button_text", "label": "Button text", "default": "#ffffff" }
+  ]
+}
+{% endschema %}

--- a/shopify/sections/a2-quiz-cta.liquid
+++ b/shopify/sections/a2-quiz-cta.liquid
@@ -95,7 +95,7 @@
     { "type": "text", "id": "heading", "label": "Heading", "default": "Not sure which A2 is yours?" },
     { "type": "textarea", "id": "subtext", "label": "Subtext", "default": "Answer a few quick questions and we’ll match you to the right model, build, and size." },
     { "type": "text", "id": "cta_label", "label": "Button label", "default": "Take the 60-second quiz" },
-    { "type": "text", "id": "foot", "label": "Fine print", "default": "" },
+    { "type": "text", "id": "foot", "label": "Fine print" },
     { "type": "text", "id": "source_label", "label": "dataLayer source label", "default": "quiz", "info": "Passed as `source` on the octane_quiz_open event (analytics only)." },
     { "type": "header", "content": "Style" },
     { "type": "color", "id": "bg_color", "label": "Background", "default": "#12161b" },

--- a/shopify/sections/a2-quiz-cta.liquid
+++ b/shopify/sections/a2-quiz-cta.liquid
@@ -1,0 +1,110 @@
+{%- comment -%}
+  A2 Bikes — Play 5: Octane quiz entry point (self-contained).
+  ---------------------------------------------------------------------------
+  A placeable "take the quiz" band. Opens the Octane AI quiz — prefers the
+  on-site JS API (window.octaneai.open / window.__octane.openQuiz) if present,
+  otherwise navigates to the quiz page URL. Pushes the `octane_quiz_open`
+  dataLayer event (GTM owns GA4/Meta). Self-contained: does NOT depend on
+  a2-lp.js, so it works on the homepage AND on PDPs (where a2-lp.js isn't loaded).
+
+  Identity note: the quiz IDENTIFIES the visitor on COMPLETION (Octane -> Klaviyo
+  -> the theme's octane-quiz-completed listener, which is wired to
+  window.a2_identify(email,"quiz")). This section only drives OPENS; the
+  `quiz` scoreboard source comes from the completion wiring in layout/theme.liquid.
+
+  Owner decision: prominence. `style` = "band" (full bleed, hero-ish) or
+  "strip" (compact). Copy + quiz URL are settings.
+{%- endcomment -%}
+
+{%- if section.settings.enable -%}
+{%- assign _url = section.settings.quiz_url | default: '/pages/a2-bikes-selector-quiz' -%}
+<div class="a2qz a2qz--{{ section.settings.style }}" id="a2qz-{{ section.id }}"
+     style="--a2qz-bg:{{ section.settings.bg_color }};--a2qz-fg:{{ section.settings.text_color }};--a2qz-btn:{{ section.settings.button_bg }};--a2qz-btntext:{{ section.settings.button_text }};">
+  <div class="a2qz__inner">
+    {%- if section.settings.eyebrow != blank -%}<p class="a2qz__eyebrow">{{ section.settings.eyebrow }}</p>{%- endif -%}
+    <h2 class="a2qz__title">{{ section.settings.heading | default: 'Not sure which A2 is yours?' }}</h2>
+    {%- if section.settings.subtext != blank -%}<p class="a2qz__sub">{{ section.settings.subtext }}</p>{%- endif -%}
+    <button type="button" class="a2qz__btn" data-a2qz-open
+            data-quiz-url="{{ _url | escape }}"
+            data-source="{{ section.settings.source_label | default: 'quiz' | escape }}">
+      {{ section.settings.cta_label | default: 'Take the 60-second quiz' }}
+    </button>
+    {%- if section.settings.foot != blank -%}<p class="a2qz__foot">{{ section.settings.foot }}</p>{%- endif -%}
+  </div>
+</div>
+
+{%- style -%}
+  #a2qz-{{ section.id }}.a2qz{background:var(--a2qz-bg);color:var(--a2qz-fg);}
+  #a2qz-{{ section.id }} .a2qz__inner{max-width:820px;margin:0 auto;padding:clamp(28px,5vw,56px) 20px;text-align:center;}
+  #a2qz-{{ section.id }}.a2qz--strip .a2qz__inner{padding:20px;display:flex;gap:16px;align-items:center;justify-content:center;flex-wrap:wrap;text-align:left;}
+  #a2qz-{{ section.id }} .a2qz__eyebrow{margin:0 0 8px;font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;opacity:.7;}
+  #a2qz-{{ section.id }} .a2qz__title{margin:0 0 10px;font-size:clamp(1.5rem,3.4vw,2.1rem);line-height:1.1;font-weight:800;}
+  #a2qz-{{ section.id }}.a2qz--strip .a2qz__title{margin:0;font-size:clamp(1.15rem,2.4vw,1.5rem);}
+  #a2qz-{{ section.id }} .a2qz__sub{margin:0 0 20px;font-size:1rem;line-height:1.5;opacity:.9;max-width:52ch;margin-left:auto;margin-right:auto;}
+  #a2qz-{{ section.id }}.a2qz--strip .a2qz__sub{display:none;}
+  #a2qz-{{ section.id }} .a2qz__btn{display:inline-block;padding:15px 28px;font-size:1rem;font-weight:700;cursor:pointer;
+    border:0;border-radius:10px;background:var(--a2qz-btn);color:var(--a2qz-btntext);text-decoration:none;}
+  #a2qz-{{ section.id }} .a2qz__btn:hover{opacity:.92;}
+  #a2qz-{{ section.id }}.a2qz--strip .a2qz__inner > *{flex:0 0 auto;}
+  #a2qz-{{ section.id }} .a2qz__foot{margin:12px 0 0;font-size:.8rem;opacity:.6;}
+{%- endstyle -%}
+
+<script>
+(function(){
+  var root = document.getElementById("a2qz-{{ section.id }}");
+  if (!root || root.__a2qzInit) return;
+  root.__a2qzInit = true;
+  var btn = root.querySelector("[data-a2qz-open]");
+  if (!btn) return;
+  btn.addEventListener("click", function(e){
+    e.preventDefault();
+    var url = btn.getAttribute("data-quiz-url");
+    var src = btn.getAttribute("data-source") || "quiz";
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: "octane_quiz_open", source: src });
+    try {
+      if (window.octaneai && typeof window.octaneai.open === "function") { window.octaneai.open(); return; }
+      if (window.__octane && typeof window.__octane.openQuiz === "function") { window.__octane.openQuiz(); return; }
+    } catch(err){}
+    if (url) { window.location.href = url; }
+  });
+})();
+</script>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "A2 Quiz CTA",
+  "tag": "section",
+  "class": "a2-quiz-cta-section",
+  "settings": [
+    { "type": "checkbox", "id": "enable", "label": "Enable", "default": true },
+    {
+      "type": "select",
+      "id": "style",
+      "label": "Prominence",
+      "options": [
+        { "value": "band", "label": "Band (large, centered)" },
+        { "value": "strip", "label": "Strip (compact row)" }
+      ],
+      "default": "band",
+      "info": "OWNER DECISION: how prominent the quiz push should be."
+    },
+    { "type": "url", "id": "quiz_url", "label": "Quiz URL", "info": "Where the quiz lives. Defaults to /pages/a2-bikes-selector-quiz. Used as a fallback if the Octane on-site API isn’t available." },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "Bike finder" },
+    { "type": "text", "id": "heading", "label": "Heading", "default": "Not sure which A2 is yours?" },
+    { "type": "textarea", "id": "subtext", "label": "Subtext", "default": "Answer a few quick questions and we’ll match you to the right model, build, and size." },
+    { "type": "text", "id": "cta_label", "label": "Button label", "default": "Take the 60-second quiz" },
+    { "type": "text", "id": "foot", "label": "Fine print", "default": "" },
+    { "type": "text", "id": "source_label", "label": "dataLayer source label", "default": "quiz", "info": "Passed as `source` on the octane_quiz_open event (analytics only)." },
+    { "type": "header", "content": "Style" },
+    { "type": "color", "id": "bg_color", "label": "Background", "default": "#12161b" },
+    { "type": "color", "id": "text_color", "label": "Text", "default": "#f6f8fa" },
+    { "type": "color", "id": "button_bg", "label": "Button background", "default": "#b4122e" },
+    { "type": "color", "id": "button_text", "label": "Button text", "default": "#ffffff" }
+  ],
+  "presets": [
+    { "name": "A2 Quiz CTA" }
+  ]
+}
+{% endschema %}

--- a/shopify/sections/overlay-group.json
+++ b/shopify/sections/overlay-group.json
@@ -1,0 +1,87 @@
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "type": "custom.overlay",
+  "name": "t:groups.overlay_group.name",
+  "sections": {
+    "quick-cart": {
+      "type": "quick-cart",
+      "settings": {
+        "enable_quick_cart": true,
+        "show_product_currency": true,
+        "continue_shopping_link": "shopify://collections/frontpage",
+        "promotion_text": "Not sure where to start? Try these collections:",
+        "collection_list": [
+          "all-accessory-bundles"
+        ],
+        "collection_list_button_style": "btn--primary"
+      }
+    },
+    "popup": {
+      "type": "popup",
+      "blocks": {
+        "popup_nQjrPG": {
+          "type": "popup",
+          "settings": {
+            "delay": "timer_0",
+            "frequency": "frequency_168",
+            "show_on_exit_intent": true,
+            "disable_for_account_holders": false,
+            "show_on_specific_page": false,
+            "target_page": "",
+            "accent": "Promotion",
+            "heading": "Announce your promotion",
+            "heading_font_class": "fs-heading-2-base",
+            "subheading": "Get a free bike",
+            "text": "<p>You also get free shipping. Use code PROMO</p>",
+            "link": "",
+            "link_text": "Start shopping",
+            "dismiss_text": "No thanks",
+            "footer_text": "<p>* Optional footer note</p>",
+            "show_social_icons": false,
+            "popup_size": "large",
+            "content_alignment": "center",
+            "image": "shopify://shop_images/DSCF9200-Edit-Edit-2-5.jpg",
+            "image_position": "top",
+            "focal_point": "top",
+            "show_image_on_mobile": true,
+            "background_color": "#ffffff",
+            "text_color": "#000000",
+            "button_background_color": "#000000",
+            "button_text_color": "#ffffff",
+            "color_overlay": "#000000",
+            "overlay_opacity": 0
+          }
+        }
+      },
+      "block_order": [
+        "popup_nQjrPG"
+      ],
+      "disabled": true,
+      "settings": {}
+    },
+    "a2-exit-intent": {
+      "type": "a2-exit-intent",
+      "settings": {
+        "enable": false
+      }
+    },
+    "17677252767c255c43": {
+      "type": "_blocks",
+      "settings": {}
+    }
+  },
+  "order": [
+    "quick-cart",
+    "popup",
+    "a2-exit-intent",
+    "17677252767c255c43"
+  ]
+}

--- a/shopify/sections/sppdp-product.liquid
+++ b/shopify/sections/sppdp-product.liquid
@@ -1,0 +1,1335 @@
+{%- comment -%}
+  SP-105 PDP — REAL PRODUCT section. Renders on a product template and wires
+  to live product data: gallery from product.media, Color/Size/Wheelset from
+  the product's variants (live price + availability), real Add to Cart, and
+  price/Affirm that update on variant change. Editorial bits (hotspots,
+  education tiles, trust) stay as section settings/blocks. Shares the .sppdp
+  CSS/JS (gallery swap, accordion, sticky bar) via snippets/sppdp-assets.
+{%- endcomment -%}
+{% render 'sppdp-assets' %}
+{%- liquid
+  assign cur = product.selected_or_first_available_variant
+  assign months = section.settings.affirm_months
+  if months == 0
+    assign months = 12
+  endif
+  assign monthly = cur.price | divided_by: 100.0 | divided_by: months | round
+  assign rating_value = section.settings.rating_value
+  assign rmeta = product.metafields.reviews.rating.value
+  if rmeta != blank and rmeta.rating != blank
+    assign rating_value = rmeta.rating
+  endif
+  assign rating_count = section.settings.rating_count
+  assign rcount = product.metafields.reviews.rating_count
+  if rcount != blank and rcount != 0
+    assign rating_count = rcount
+  endif
+  assign color_pos = ''
+  assign size_pos = ''
+  for o in product.options_with_values
+    assign od = o.name | downcase
+    if od == 'color' or od == 'colour' or od == 'colorway'
+      assign color_pos = o.position
+      assign cur_color = o.selected_value
+    endif
+    if od == 'size'
+      assign size_pos = o.position
+    endif
+  endfor
+-%}
+{%- liquid
+  assign calc_bike = 'sp'
+  if product.handle contains 'rogue'
+    assign calc_bike = 'rogue'
+  endif
+-%}
+{%- capture size_calc_details -%}
+  {%- if section.settings.show_size_calc -%}
+  <section class="sppdp-fitband" id="find-your-fit" aria-label="Find your size">
+    {% render 'a2-fit-engine', model: calc_bike %}
+  </section>
+  <style>
+    .sppdp-fitband{ margin:22px 0 6px; scroll-margin-top:80px; --a2-bg:#ffffff; --a2-fg:#14181d; --a2-border:rgba(15,20,25,.14); --a2-accent:#b4122e; --a2-accent-2:#14181d; --a2-accent-fg:#ffffff; --a2-font-display:"Bahnschrift","DIN Condensed","Oswald","Arial Narrow",system-ui,sans-serif; }
+    .sppdp-fitband__head{ margin-bottom:14px; }
+    .sppdp-fitband__kicker{ display:block; text-transform:uppercase; letter-spacing:.14em; font-size:.72rem; color:#b4122e; }
+    .sppdp-fitband__title{ margin:.12em 0 .6em; font-size:clamp(1.4rem,2.6vw,2rem); }
+    .sppdp-fitband.is-flash{ animation:sppdpFitFlash 1.4s ease; }
+    @keyframes sppdpFitFlash{ 0%,100%{ box-shadow:0 0 0 0 rgba(180,18,46,0); } 25%{ box-shadow:0 0 0 4px rgba(180,18,46,.18); } }
+  </style>
+  <script>
+    (function(){
+      if(window.__a2FitJump) return; window.__a2FitJump = true;
+      document.addEventListener('click', function(e){
+        var a = e.target.closest('[data-fitjump]'); if(!a) return;
+        e.preventDefault();
+        // Primary: open the condensed fit drawer (a2-fit-engine).
+        if(window.A2Fit && typeof window.A2Fit.openDrawer === 'function'){ window.A2Fit.openDrawer(); return; }
+        // Fallback (engine not booted yet): scroll to the inline finder and flash it.
+        var band = document.getElementById('find-your-fit'); if(!band) return;
+        requestAnimationFrame(function(){ requestAnimationFrame(function(){
+          var y = window.pageYOffset + band.getBoundingClientRect().top - 88;
+          window.scrollTo({ top: Math.max(0, y), behavior: 'smooth' });
+          band.classList.remove('is-flash'); void band.offsetWidth; band.classList.add('is-flash');
+        }); });
+      });
+    })();
+  </script>
+  {%- endif -%}
+{%- endcapture -%}
+<div class="sppdp" id="sppdp-pdp-{{ section.id }}">
+  <div class="pdp-wrap">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="/">{{ section.settings.bc_home }}</a><span class="sep">/</span>
+      <a href="{{ section.settings.bc_col_url | default: '/collections/sp' }}">{{ section.settings.bc_col }}</a><span class="sep">/</span>
+      <span class="here">{{ product.title }}</span>
+    </nav>
+  </div>
+
+  <main class="pdp-wrap pdp-main">
+    <!-- DESKTOP GALLERY (from product.media) -->
+    <section class="gallery" aria-label="Product gallery">
+      <div class="gallery__rail">
+        {%- for media in product.media -%}
+          <button class="thumb{% if forloop.first %} active{% endif %}" data-thumb data-media-id="{{ media.id }}" data-color="{{ media.alt | escape }}" data-cap="{{ media.alt | default: product.title | escape }}" data-img="{{ media.preview_image | image_url: width: 1280 }}">
+            <img src="{{ media.preview_image | image_url: width: 200 }}" alt="{{ media.alt | default: product.title | escape }}" loading="lazy">
+          </button>
+        {%- endfor -%}
+        <button class="thumb-toggle" type="button" data-thumb-toggle aria-expanded="false" hidden>
+          <span data-thumb-toggle-label>Show more</span>
+          <svg class="thumb-toggle__chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+        </button>
+      </div>
+
+      {%- assign stage_media = product.media.first -%}
+      <div class="stage">
+        {% if cur_color != blank %}<span class="stage__badge" data-stage-badge>{{ cur_color }}</span>{% endif %}
+        {% if stage_media %}<img data-stage-img src="{{ stage_media.preview_image | image_url: width: 1280 }}" alt="{{ stage_media.alt | default: product.title | escape }}">{% else %}<div class="ph" data-stage-img>{{ product.title }}</div>{% endif %}
+        {%- if section.settings.show_hotspots -%}
+          {%- assign mi = 0 -%}
+          {%- for media in product.media limit: 6 -%}
+            {%- assign mi = mi | plus: 1 -%}
+            {%- assign grp_count = 0 -%}
+            {%- for block in section.blocks -%}{% if block.type == 'hotspot' and block.settings.image_index == mi %}{% assign grp_count = grp_count | plus: 1 %}{% endif %}{%- endfor -%}
+            {%- if grp_count > 0 -%}
+              <div class="sppdp-hotspots" data-hotspots data-img-src="{{ media.preview_image | image_url: width: 1280 }}"{% unless forloop.first %} style="display:none"{% endunless %}>
+                {%- assign hn = 0 -%}
+                {%- for block in section.blocks -%}
+                  {%- if block.type == 'hotspot' and block.settings.image_index == mi -%}
+                    {%- assign hn = hn | plus: 1 -%}
+                    <span class="hotspot" style="left:{{ block.settings.x }}%;top:{{ block.settings.y }}%" {{ block.shopify_attributes }}>{{ hn }}<span class="hotspot__label">{{ block.settings.label }}</span></span>
+                  {%- endif -%}
+                {%- endfor -%}
+              </div>
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif -%}
+      </div>
+      {%- if section.settings.gallery_caption != blank -%}
+      <p class="gallery__caption" data-stage-cap><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>{{ section.settings.gallery_caption }}</p>
+      {%- endif -%}
+
+      <div class="edu-row">
+        {%- for n in (1..3) -%}
+          {%- assign k_t = 'edu_' | append: n | append: '_title' -%}
+          {%- assign et = section.settings[k_t] -%}
+          {%- if et != blank -%}
+            {%- assign k_i = 'edu_' | append: n | append: '_image' -%}
+            {%- assign k_d = 'edu_' | append: n | append: '_desc' -%}
+            {%- assign eimg = section.settings[k_i] -%}
+            <article class="edu-tile">
+              <div class="edu-tile__img">{% if eimg %}<img src="{{ eimg | image_url: width: 600 }}" alt="{{ et | escape }}" loading="lazy">{% else %}<div class="ph">{{ et }}</div>{% endif %}</div>
+              <div class="edu-tile__body">
+                <div class="edu-tile__title">{{ et }}</div>
+                <p class="edu-tile__desc">{{ section.settings[k_d] }}</p>
+              </div>
+            </article>
+          {%- endif -%}
+        {%- endfor -%}
+      </div>
+
+      {% render 'sppdp-info-accordion', section: section, product: product %}
+    </section>
+
+    <!-- MOBILE SWIPE GALLERY -->
+    <section class="m-gallery" aria-label="Product gallery">
+      <div class="m-gallery__track" data-gallery-track>
+        {%- for media in product.media -%}
+          <div class="m-slide" data-media-id="{{ media.id }}" data-color="{{ media.alt | escape }}">
+            <img src="{{ media.preview_image | image_url: width: 900 }}" alt="{{ media.alt | default: product.title | escape }}" loading="lazy">
+            {% if media.alt != blank %}<div class="m-slide__cap">{{ media.alt }}</div>{% endif %}
+          </div>
+        {%- endfor -%}
+      </div>
+      <div class="m-gallery__dots">
+        {%- for media in product.media -%}
+          <span{% if forloop.first %} class="on"{% endif %} data-gallery-dot data-media-id="{{ media.id }}" data-color="{{ media.alt | escape }}"></span>
+        {%- endfor -%}
+      </div>
+    </section>
+
+    <!-- BUY BOX -->
+    <aside class="buybox" aria-label="Purchase options">
+      <div class="buybox__head">
+        <span class="buybox__kicker">{{ section.settings.kicker }}</span>
+        <h1 class="buybox__title">{{ product.title }}</h1>
+        <p class="buybox__subtitle">{{ section.settings.subtitle | default: product.type }}</p>
+      </div>
+
+      {%- assign sp_collection = collections[section.settings.build_collection] -%}
+      {%- if sp_collection != blank and sp_collection.products.size > 1 -%}
+      <div class="build-switch">
+        <div class="optgroup__label"><span class="lbl">{{ section.settings.build_label }}</span></div>
+        <div class="build-pills">
+          {%- assign builds = sp_collection.products | sort: 'price' -%}
+          {%- for bp in builds -%}
+            {%- assign blabel = bp.metafields.custom.siblings_color.value | default: bp.title -%}
+            {%- if bp.handle == product.handle -%}
+              <span class="build-pill is-active" aria-current="true">{{ blabel }}</span>
+            {%- else -%}
+              <a class="build-pill" href="{{ bp.url }}">{{ blabel }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </div>
+      {%- endif -%}
+
+      <div class="ratingline">
+        <span class="stars">{{ section.settings.rating_stars }}</span>
+        <span><b>{{ rating_value }}</b></span>
+        <a href="{{ section.settings.reviews_anchor | default: '#sppdp-reviews' }}">{% if rating_count != blank and rating_count != 0 %}{{ rating_count }} verified reviews{% else %}Read reviews{% endif %}</a>
+      </div>
+
+      <div class="price-block">
+        <div class="price-row">
+          <span class="price" data-price>{{ cur.price | money_without_trailing_zeros }}</span>
+          {% if cur.compare_at_price > cur.price %}<span class="price-note"><s data-compare>{{ cur.compare_at_price | money_without_trailing_zeros }}</s></span>{% endif %}
+          <span class="price-note">{{ section.settings.price_note }}</span>
+        </div>
+        {%- if section.settings.show_affirm_line -%}
+        <div class="affirm">
+          {%- comment -%} Affirm's own component renders the compliant
+            as-low-as language + logo (needs the Affirm app block / affirm.js;
+            stays empty without it). {%- endcomment -%}
+          <p class="affirm-as-low-as" data-page-type="product" data-amount="{{ cur.price }}"></p>
+          <a href="{{ section.settings.affirm_url | default: '/pages/financing-hsa-fsa' }}">Financing options →</a>
+        </div>
+        {%- endif -%}
+        {%- assign wheel_save = product.metafields.custom.wheel_upgrade.value -%}
+        {%- assign wu_url = product.metafields.custom.wheel_upgrade_url.value -%}
+        {%- assign wu_var = product.metafields.custom.wheel_upgrade_variant.value -%}
+        {%- assign wu_var2 = product.metafields.custom.wheel_upgrade_variant_2.value -%}
+        {%- assign credit_cents = 0 -%}
+        {%- if product.metafields.custom.wheel_upgrade_credit.value != blank -%}{%- assign credit_cents = product.metafields.custom.wheel_upgrade_credit.value | times: 100 -%}{%- endif -%}
+        {%- assign has_opt1 = false -%}{%- if wu_var != blank and wu_var.id -%}{%- assign has_opt1 = true -%}{%- endif -%}
+        {%- assign has_opt2 = false -%}{%- if wu_var2 != blank and wu_var2.id -%}{%- assign has_opt2 = true -%}{%- endif -%}
+        {%- if wheel_save != blank or has_opt1 or has_opt2 -%}
+        {%- if has_opt1 and has_opt2 -%}
+        <div class="wheel-upsell wheel-upsell--opts">
+          <label class="wheel-upsell__opt">
+            <input type="checkbox" data-wheel-upgrade data-wheel-net="{{ wu_var.price | minus: credit_cents }}" value="{{ wu_var.id }}">
+            <span class="wheel-upsell__txt">
+              <span class="wheel-upsell__title">Add {{ wu_var.product.title }} — <b>+{{ wu_var.price | minus: credit_cents | money_without_trailing_zeros }}</b>{% if credit_cents > 0 %} <span class="wheel-upsell__save">Save {{ credit_cents | money_without_trailing_zeros }}</span>{% endif %}</span>
+            </span>
+          </label>
+          <label class="wheel-upsell__opt">
+            <input type="checkbox" data-wheel-upgrade data-wheel-net="{{ wu_var2.price | minus: credit_cents }}" value="{{ wu_var2.id }}">
+            <span class="wheel-upsell__txt">
+              <span class="wheel-upsell__title">Add {{ wu_var2.product.title }} — <b>+{{ wu_var2.price | minus: credit_cents | money_without_trailing_zeros }}</b>{% if credit_cents > 0 %} <span class="wheel-upsell__save">Save {{ credit_cents | money_without_trailing_zeros }}</span>{% endif %}</span>
+            </span>
+          </label>
+          <span class="wheel-upsell__note">{{ section.settings.wheel_note }}</span>
+        </div>
+        {%- elsif has_opt1 -%}
+        <div class="wheel-upsell">
+          <label class="wheel-upsell__opt">
+            <input type="checkbox" data-wheel-upgrade data-wheel-net="{{ wu_var.price | minus: credit_cents }}" value="{{ wu_var.id }}">
+            <span class="wheel-upsell__txt">
+              <span class="wheel-upsell__title">Add {{ wu_var.product.title }} — <b>+{{ wu_var.price | minus: credit_cents | money_without_trailing_zeros }}</b>{% if credit_cents > 0 %} <span class="wheel-upsell__save">Save {{ credit_cents | money_without_trailing_zeros }}</span>{% endif %}</span>
+              <span class="wheel-upsell__note">{{ section.settings.wheel_note }}</span>
+            </span>
+          </label>
+        </div>
+        {%- else -%}
+        <div class="wheel-upsell">
+          <span class="wheel-upsell__ico"><svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="2.6"/><path d="M12 3.5v3M12 17.5v3M3.5 12h3M17.5 12h3M6.3 6.3l2.1 2.1M15.6 15.6l2.1 2.1M17.7 6.3l-2.1 2.1M8.4 15.6l-2.1 2.1"/></svg></span>
+            <span class="wheel-upsell__txt">
+              <span class="wheel-upsell__title">{{ wheel_save }}</span>
+              <span class="wheel-upsell__note">{{ section.settings.wheel_note }} <a href="{{ wu_url | default: '/collections/wheelsets-and-upgrades' }}">Shop the wheels →</a></span>
+            </span>
+        </div>
+        {%- endif -%}
+        {%- endif -%}
+      </div>
+
+      <hr class="rule">
+
+      <form method="post" action="/cart/add" data-product-form>
+        <input type="hidden" name="id" value="{{ cur.id }}" data-variant-id>
+
+        {%- for option in product.options_with_values -%}
+          {%- assign odown = option.name | downcase -%}
+          <div class="optgroup">
+            <div class="optgroup__label">
+              <span class="lbl">{{ option.name }}</span>
+              {%- if odown == 'size' -%}
+                {%- if section.settings.show_size_calc -%}
+                <a class="help-link" href="#find-your-fit" data-fitjump><svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z"/><path d="M12 12v9M12 12L4 7.5M12 12l8-4.5"/></svg>{{ section.settings.size_help_label | default: 'Find your size' }}</a>
+                {%- else -%}
+                <a class="help-link" href="{{ section.settings.size_help_url | default: '#sppdp-specs' }}"><svg viewBox="0 0 24 24"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z"/><path d="M12 12v9M12 12L4 7.5M12 12l8-4.5"/></svg>{{ section.settings.size_help_label }}</a>
+                {%- endif -%}
+              {%- elsif odown == 'color' or odown == 'colour' or odown == 'colorway' -%}
+                <span class="val"><b data-swatch-name>{{ option.selected_value }}</b></span>
+              {%- endif -%}
+            </div>
+            {%- if odown == 'color' or odown == 'colour' or odown == 'colorway' -%}
+              <div class="swatches">
+                {%- for value in option.values -%}
+                  {%- assign vd = value | downcase -%}
+                  {%- assign grad = 'linear-gradient(150deg,#6A6F75 0%,#3A3C40 100%)' -%}
+                  {%- if vd contains 'red' -%}{%- assign grad = 'linear-gradient(150deg,#E5322B 0%,#A01913 100%)' -%}
+                  {%- elsif vd contains 'silver' -%}{%- assign grad = 'linear-gradient(150deg,#C9CDD2 0%,#33363B 100%)' -%}
+                  {%- elsif vd contains 'blue' -%}{%- assign grad = 'linear-gradient(150deg,#3A6076 0%,#1A3142 100%)' -%}
+                  {%- elsif vd contains 'grey' or vd contains 'gray' -%}{%- assign grad = 'linear-gradient(150deg,#A6ACB1 0%,#6C7176 100%)' -%}
+                  {%- elsif vd contains 'black' -%}{%- assign grad = 'linear-gradient(150deg,#2A2C30 0%,#0E0F11 100%)' -%}
+                  {%- endif -%}
+                  <button type="button" class="swatch" data-opt="{{ option.position }}" data-value="{{ value | escape }}" aria-pressed="{% if value == option.selected_value %}true{% else %}false{% endif %}"><span class="swatch__chip" style="background:{{ grad }}"></span><span class="swatch__name">{{ value }}</span></button>
+                {%- endfor -%}
+              </div>
+            {%- else -%}
+              <div class="sizes">
+                {%- for value in option.values -%}
+                  <button type="button" class="size-pill" data-opt="{{ option.position }}" data-value="{{ value | escape }}" aria-pressed="{% if value == option.selected_value %}true{% else %}false{% endif %}">{{ value }}</button>
+                {%- endfor -%}
+              </div>
+              {%- if odown == 'size' -%}
+                <div class="optgroup__label"><span class="val" data-size-val>Selected: <b>{{ option.selected_value }}</b></span></div>
+              {%- endif -%}
+            {%- endif -%}
+          </div>
+        {%- endfor -%}
+
+        <div class="cta-stack" style="margin-top:6px">
+          <button type="submit" class="btn btn--primary btn-addcart" data-atc{% unless cur.available %} disabled{% endunless %}><span class="btn-label">{% if cur.available %}{{ section.settings.cta_prefix }}{{ cur.price | money_without_trailing_zeros }}{% else %}Sold out{% endif %}</span></button>
+          <div class="cta-sub">
+            <span class="demo"><svg viewBox="0 0 24 24"><path d="M3 12l2-7h14l2 7M5 12h14v5a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2z"/></svg>{{ section.settings.demo_note }}</span>
+            <a href="{{ section.settings.consult_url | default: '/pages/contact-a2-bikes' }}" data-buybox-end>{{ section.settings.consult_label }}</a>
+          </div>
+        </div>
+      </form>
+{% render 'a2-save-build', enabled: section.settings.enable_save_build, klaviyo_company: section.settings.sb_klaviyo_company, klaviyo_list: section.settings.sb_klaviyo_list %}
+
+      {%- comment -%} GovX military / first-responder verify — app block(s)
+        rendered directly beneath the Add to Cart (verify-to-unlock decision
+        point). Kept OUTSIDE the buy-box <form>: GovX renders its own controls,
+        so nesting would create a nested form. Styled as an A2 secondary/ghost
+        button via .govx-slot in the section CSS below, subordinate to the black
+        primary ATC. Add the GovX app block to each product template to show it. {%- endcomment -%}
+      {%- assign app_block_count = 0 -%}
+      {%- for b in section.blocks -%}{% if b.type == '@app' %}{% assign app_block_count = app_block_count | plus: 1 %}{% endif %}{%- endfor -%}
+      {%- if app_block_count > 0 -%}
+      <div class="govx-slot">
+        {%- for block in section.blocks -%}
+          {%- if block.type == '@app' -%}<div class="govx-app" {{ block.shopify_attributes }}>{% render block %}</div>{%- endif -%}
+        {%- endfor -%}
+      </div>
+      {%- endif -%}
+
+      {%- comment -%} SP restock / new-drop alert — renders only on products flagged custom.restock_alert; loads a2-lp assets only when shown. Kept OUTSIDE the buy-box <form> (no nested forms). {%- endcomment -%}
+      {%- if product.metafields.custom.restock_alert -%}
+        {% render 'a2-restock-alert', product: product %}
+        <script src="{{ 'a2-lp.js' | asset_url }}" defer></script>
+      {%- endif -%}
+
+      {%- assign trust_count = 0 -%}
+      {%- for b in section.blocks -%}{% if b.type == 'trust' %}{% assign trust_count = trust_count | plus: 1 %}{% endif %}{%- endfor -%}
+      {%- if trust_count > 0 -%}
+      <div class="trust">
+        {%- for b in section.blocks -%}
+          {%- if b.type != 'trust' -%}{%- continue -%}{%- endif -%}
+          <div class="trust__item" {{ b.shopify_attributes }}>
+            {% render 'sppdp-icon', icon: b.settings.icon %}
+            <div><div class="t-title">{{ b.settings.title }}</div><div class="t-sub">{{ b.settings.sub }}</div></div>
+          </div>
+        {%- endfor -%}
+      </div>
+      {%- endif -%}
+    </aside>
+  </main>
+
+  {%- if section.settings.show_size_calc -%}
+  <div class="pdp-wrap">{{ size_calc_details }}</div>
+  {%- endif -%}
+
+  {%- if section.settings.show_sticky -%}
+  <div class="sticky-buy" data-sticky-buy>
+    <div class="sticky-buy__info">
+      <div class="sticky-buy__name">{{ product.title }}{% if cur_color != blank %} · <span data-swatch-name>{{ cur_color }}</span>{% endif %}</div>
+      <div class="sticky-buy__price"><b data-price>{{ cur.price | money_without_trailing_zeros }}</b> · <span class="affirm-as-low-as" data-page-type="product" data-amount="{{ cur.price }}">pay monthly with Affirm</span></div>
+    </div>
+    <button type="button" class="btn btn--primary" data-atc{% unless cur.available %} disabled{% endunless %}><span class="btn-label">{% if cur.available %}Add to cart{% else %}Sold out{% endif %}</span></button>
+  </div>
+  {%- endif -%}
+
+  <style>
+    #sppdp-pdp-{{ section.id }} .is-unavailable{ opacity:.45; }
+    #sppdp-pdp-{{ section.id }} .size-pill.is-unavailable{ text-decoration:line-through; border-style:dashed; }
+    #sppdp-pdp-{{ section.id }} .affirm-app{ margin-top:2px; }
+    /* GovX verify slot — sits directly under the primary ATC. Rendered as an A2
+       secondary/ghost button (white fill + ink hairline), deliberately quieter
+       than the black Add-to-Cart so it never competes with the primary CTA.
+       GovX controls its own inner markup, so we scope the ghost styling to the
+       button/link it renders inside .govx-slot. */
+    #sppdp-pdp-{{ section.id }} .govx-slot{ margin-top:10px; }
+    #sppdp-pdp-{{ section.id }} .govx-slot .govx-app :is(a,button){
+      display:flex; align-items:center; justify-content:center; gap:9px;
+      width:100%; box-sizing:border-box; min-height:46px; padding:12px 16px;
+      background:var(--paper); color:var(--ink);
+      border:1.5px solid var(--ink); border-radius:10px;
+      font-family:inherit; font-size:.9rem; font-weight:600; letter-spacing:.01em;
+      line-height:1.2; text-align:center; text-decoration:none; cursor:pointer;
+      transition:background .15s ease, border-color .15s ease;
+    }
+    #sppdp-pdp-{{ section.id }} .govx-slot .govx-app :is(a,button):hover{ background:var(--paper-2); }
+    #sppdp-pdp-{{ section.id }} .govx-slot .govx-app :is(a,button) svg,
+    #sppdp-pdp-{{ section.id }} .govx-slot .govx-app :is(a,button) img{ width:18px; height:18px; flex:0 0 auto; }
+    /* Affirm's ALA template renders "…with Affirm.See if you qualify" with no
+       space before the trailing CTA (Affirm controls that text). Nudge a gap
+       in front of the trailing link/trigger so it reads "Affirm. See if…". */
+    #sppdp-pdp-{{ section.id }} .affirm-as-low-as > a:last-child,
+    #sppdp-pdp-{{ section.id }} .affirm-as-low-as > span:last-child,
+    #sppdp-pdp-{{ section.id }} .affirm-as-low-as .affirm-modal-trigger:last-child{ margin-left:.28em; }
+    /* Size calculator nested in the left/gallery column: span the FULL column
+       (the gallery is a 76px-rail + 1fr grid, so without this it collapses into
+       the 76px thumbnail track) and drop the auto-centering so it fills the
+       space beside the taller buy box. */
+    #sppdp-pdp-{{ section.id }} .gallery > .sppdp-fitband{ grid-column:1 / -1; width:100%; max-width:none; margin-left:0; margin-right:0; }
+    /* Collapsible thumbnail rail: hidden overflow thumbs + the "+N more" toggle. */
+    #sppdp-pdp-{{ section.id }} .thumb[hidden]{ display:none !important; }
+    #sppdp-pdp-{{ section.id }} .thumb-toggle{ display:flex; align-items:center; justify-content:center; gap:6px; width:100%; margin-top:2px; padding:9px 6px; border:1.5px dashed var(--line); border-radius:9px; background:var(--paper); cursor:pointer; font-family:inherit; font-size:.78rem; font-weight:600; letter-spacing:.01em; color:var(--ink); transition:border-color .15s, background .15s, color .15s; }
+    #sppdp-pdp-{{ section.id }} .thumb-toggle:hover{ border-color:var(--ink); background:var(--paper-2); }
+    #sppdp-pdp-{{ section.id }} .thumb-toggle[hidden]{ display:none !important; }
+    #sppdp-pdp-{{ section.id }} .thumb-toggle__chev{ width:15px; height:15px; flex:0 0 auto; transition:transform .2s ease; }
+    #sppdp-pdp-{{ section.id }} .thumb-toggle[aria-expanded="true"] .thumb-toggle__chev{ transform:rotate(180deg); }
+    #sppdp-pdp-{{ section.id }} .build-switch{ display:flex; flex-direction:column; gap:9px; margin-top:14px; }
+    #sppdp-pdp-{{ section.id }} .build-pills{ display:flex; gap:8px; flex-wrap:wrap; }
+    #sppdp-pdp-{{ section.id }} .build-pill{ display:inline-flex; align-items:center; min-height:42px; padding:0 14px; border:1.5px solid var(--line); border-radius:8px; font-size:.9rem; font-weight:600; color:var(--ink); text-decoration:none; transition:border-color .15s, background .15s, color .15s; }
+    #sppdp-pdp-{{ section.id }} a.build-pill:hover{ border-color:var(--ink); }
+    #sppdp-pdp-{{ section.id }} .build-pill.is-active{ background:var(--ink); border-color:var(--ink); color:#fff; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell{ display:flex; align-items:flex-start; gap:10px; margin-top:6px; padding:12px 14px; border:1px solid rgba(31,138,76,.32); background:rgba(31,138,76,.07); border-radius:10px; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell--opts{ flex-direction:column; gap:9px; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__ico{ flex:0 0 auto; margin-top:1px; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__ico svg{ width:20px; height:20px; stroke:#1F8A4C; fill:none; stroke-width:1.8; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__opt{ display:flex; align-items:flex-start; gap:10px; cursor:pointer; width:100%; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__opt input{ margin-top:3px; width:16px; height:16px; accent-color:#1F8A4C; flex:0 0 auto; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__txt{ display:flex; flex-direction:column; gap:2px; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__title{ font-size:.92rem; font-weight:700; color:var(--ink); letter-spacing:-0.01em; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__save{ color:#1F8A4C; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__note{ font-size:.8rem; color:var(--muted); line-height:1.4; }
+    #sppdp-pdp-{{ section.id }} .wheel-upsell__note a{ color:var(--accent); font-weight:600; white-space:nowrap; }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta{ display:flex; align-items:center; gap:11px; margin:10px 0 2px; padding:11px 14px; border:1.5px solid var(--accent); border-radius:10px; background:rgba(180,18,46,.05); color:var(--ink); text-decoration:none; transition:background .15s ease; }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta:hover{ background:rgba(180,18,46,.11); }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta__ico{ flex:0 0 auto; }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta__ico svg{ width:24px; height:24px; stroke:var(--accent); fill:none; stroke-width:1.7; }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta__txt{ display:flex; flex-direction:column; line-height:1.25; }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta__txt b{ font-size:.95rem; color:var(--ink); }
+    #sppdp-pdp-{{ section.id }} .sppdp-fitcta__txt span{ font-size:.82rem; color:var(--accent); font-weight:600; }
+  </style>
+  <script>
+  (function(){
+    var R = document.getElementById('sppdp-pdp-{{ section.id }}');
+    if(!R || R.dataset.vinit) return; R.dataset.vinit = '1';
+    var variants = {{ product.variants | json }};
+    var months = {{ months }};
+    var ctaPrefix = {{ section.settings.cta_prefix | json }};
+    var colorPos = {{ color_pos | json }}, sizePos = {{ size_pos | json }};
+    var THUMB_COLLAPSED = 5; // thumbnails shown before the "+N more" toggle
+    var railExpanded = false;
+    var form = R.querySelector('[data-product-form]');
+    // Hotspots annotate one specific image — show them only when the stage is
+    // on that image, hide them when the shopper browses to other photos.
+    var stageEl = R.querySelector('[data-stage-img]');
+    var toggleBtn = R.querySelector('[data-thumb-toggle]');
+    var toggleLabel = R.querySelector('[data-thumb-toggle-label]');
+    var hotspotGroups = R.querySelectorAll('[data-hotspots]');
+    function syncHotspots(){
+      if(!stageEl || !hotspotGroups.length) return;
+      var src = stageEl.getAttribute('src');
+      hotspotGroups.forEach(function(g){ g.style.display = (g.getAttribute('data-img-src') === src) ? '' : 'none'; });
+    }
+    if(stageEl && hotspotGroups.length && stageEl.tagName === 'IMG'){
+      new MutationObserver(syncHotspots).observe(stageEl, {attributes:true, attributeFilter:['src']});
+      syncHotspots();
+    }
+    // Which thumbnails match the selected colorway (alt text). Images tagged
+    // with more than one color (comma) or no color are shared across colors.
+    function colorThumbs(){
+      var colorVal = colorPos ? sel[colorPos] : null;
+      var out = [];
+      R.querySelectorAll('[data-thumb]').forEach(function(t){
+        var c = (t.getAttribute('data-color') || '').trim();
+        var shared = (c === '') || (c.indexOf(',') !== -1);
+        if(!colorPos || shared || c === colorVal) out.push(t);
+      });
+      return out;
+    }
+    // Show the matching thumbnails; if collapsed, only the first N, with the
+    // rest behind a "+N more" toggle. Non-matching thumbnails stay hidden.
+    function renderRail(){
+      var matches = colorThumbs();
+      var matchSet = new Set(matches);
+      R.querySelectorAll('[data-thumb]').forEach(function(t){ if(!matchSet.has(t)) t.hidden = true; });
+      var overflow = matches.length - THUMB_COLLAPSED;
+      matches.forEach(function(t, i){
+        t.hidden = (!railExpanded && i >= THUMB_COLLAPSED);
+      });
+      if(toggleBtn){
+        if(overflow > 0){
+          toggleBtn.hidden = false;
+          toggleBtn.setAttribute('aria-expanded', railExpanded ? 'true' : 'false');
+          if(toggleLabel) toggleLabel.textContent = railExpanded ? 'Show less' : ('+' + overflow + ' more');
+        } else {
+          toggleBtn.hidden = true;
+        }
+      }
+      return matches.length ? matches[0] : null;
+    }
+    function filterMobile(){
+      if(!colorPos) return;
+      var colorVal = sel[colorPos];
+      R.querySelectorAll('.m-slide[data-color], [data-gallery-dot]').forEach(function(el){
+        var c = (el.getAttribute('data-color') || '').trim();
+        var shared = (c === '') || (c.indexOf(',') !== -1);
+        el.style.display = (shared || c === colorVal) ? '' : 'none';
+      });
+    }
+    function money(c){ return '$' + (c/100).toLocaleString('en-US',{minimumFractionDigits:0,maximumFractionDigits:0}); }
+    var groups = {};
+    R.querySelectorAll('[data-opt]').forEach(function(b){ var o=b.getAttribute('data-opt'); (groups[o]=groups[o]||[]).push(b); });
+    var sel = {};
+    Object.keys(groups).forEach(function(o){
+      var on = groups[o].filter(function(b){return b.getAttribute('aria-pressed')==='true';})[0] || groups[o][0];
+      sel[o] = on.getAttribute('data-value');
+    });
+    function matches(v, ovPos, ovVal){
+      for(var k in groups){
+        var want = (k===ovPos) ? ovVal : sel[k];
+        var ov = v['option'+k];
+        if(ov!=null && String(ov)!==want) return false;
+      }
+      return true;
+    }
+    function find(){ return variants.filter(function(v){ return matches(v); })[0]; }
+    function someAvailable(pos, val){ return variants.some(function(v){ return v.available && matches(v, pos, val); }); }
+    function setAll(q, val){ R.querySelectorAll(q).forEach(function(el){ el.textContent = val; }); }
+    function wheelNet(){ var n=0; R.querySelectorAll('[data-wheel-upgrade]').forEach(function(w){ if(w.checked){ n += parseInt(w.getAttribute('data-wheel-net')||'0',10); } }); return n; }
+    function markAvailability(){
+      Object.keys(groups).forEach(function(o){
+        groups[o].forEach(function(b){ b.classList.toggle('is-unavailable', !someAvailable(o, b.getAttribute('data-value'))); });
+      });
+    }
+    function activateThumb(thumb){
+      if(!thumb) return;
+      R.querySelectorAll('[data-thumb]').forEach(function(t){ t.classList.remove('active'); });
+      thumb.classList.add('active');
+      var st = R.querySelector('[data-stage-img]');
+      if(st && st.tagName==='IMG' && thumb.getAttribute('data-img')){ st.src = thumb.getAttribute('data-img'); }
+    }
+    function update(){
+      var v = find();
+      markAvailability();
+      if(colorPos) setAll('[data-swatch-name]', sel[colorPos]);
+      if(sizePos){ var sv=R.querySelector('[data-size-val]'); if(sv) sv.innerHTML = 'Selected: <b>'+sel[sizePos]+'</b>'; }
+      var badge = R.querySelector('[data-stage-badge]'); if(badge && colorPos) badge.textContent = sel[colorPos];
+      var idIn = R.querySelector('[data-variant-id]');
+      var atcs = R.querySelectorAll('[data-atc]');
+      var wn = wheelNet();
+      if(v){
+        if(idIn) idIn.value = v.id;
+        setAll('[data-price]', money(v.price + wn));
+        /* Update Affirm's own as-low-as components (main + sticky) to the live
+           variant price and let Affirm re-render — never hardcode a "$X/mo". */
+        var alas = R.querySelectorAll('.affirm-as-low-as');
+        for(var ai=0; ai<alas.length; ai++){ alas[ai].setAttribute('data-amount', (v.price + wn)); }
+        if(window.affirm && window.affirm.ui && window.affirm.ui.refresh) window.affirm.ui.refresh();
+        if(colorPos){
+          railExpanded = false; // re-collapse when the colorway changes
+          var firstThumb = renderRail();
+          filterMobile();
+          // Prefer the variant's own featured image if its thumbnail is in the
+          // matching set; otherwise fall back to the first thumbnail for color.
+          var target = null;
+          if(v.featured_media && v.featured_media.id){
+            var cand = R.querySelector('[data-thumb][data-media-id="'+v.featured_media.id+'"]');
+            if(cand){
+              var cc = (cand.getAttribute('data-color') || '').trim();
+              var ccShared = (cc === '') || (cc.indexOf(',') !== -1);
+              if(ccShared || cc === sel[colorPos]) target = cand;
+            }
+          }
+          activateThumb(target || firstThumb);
+        } else if(v.featured_image && v.featured_image.src){
+          var st0=R.querySelector('[data-stage-img]'); if(st0 && st0.tagName==='IMG'){ st0.src = v.featured_image.src; }
+        }
+      }
+      atcs.forEach(function(b){
+        var l=b.querySelector('.btn-label');
+        if(v && v.available){ b.disabled=false; if(l) l.textContent = b.classList.contains('btn-addcart') ? (ctaPrefix + money(v.price + wn)) : 'Add to cart'; }
+        else { b.disabled=true; if(l) l.textContent = v ? 'Sold out' : 'Unavailable'; }
+      });
+    }
+    // "+N more" / "Show less" toggle.
+    if(toggleBtn){
+      toggleBtn.addEventListener('click', function(){
+        railExpanded = !railExpanded;
+        renderRail();
+      });
+    }
+    // Manual thumbnail clicks still swap the stage image.
+    R.querySelectorAll('[data-thumb]').forEach(function(t){
+      t.addEventListener('click', function(){ activateThumb(t); });
+    });
+    R.querySelectorAll('[data-opt]').forEach(function(b){
+      b.addEventListener('click', function(){
+        var o=b.getAttribute('data-opt');
+        groups[o].forEach(function(x){ x.setAttribute('aria-pressed','false'); });
+        b.setAttribute('aria-pressed','true');
+        sel[o]=b.getAttribute('data-value');
+        update();
+      });
+    });
+    var wheelOpts = R.querySelectorAll('[data-wheel-upgrade]');
+    wheelOpts.forEach(function(w){
+      w.addEventListener('change', function(){
+        if(w.checked){ wheelOpts.forEach(function(o){ if(o!==w){ o.checked=false; } }); }
+        update();
+      });
+    });
+    R.querySelectorAll('[data-atc]').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        if(btn.disabled) return;
+        var v=find(); if(!v || !v.available) return;
+        e.preventDefault();
+        var l=btn.querySelector('.btn-label'); if(l) l.textContent='Adding…';
+        var items=[{id:v.id, quantity:1}];
+        R.querySelectorAll('[data-wheel-upgrade]').forEach(function(wu){
+          if(wu.checked && wu.value){ items.push({id: parseInt(wu.value,10), quantity:1}); }
+        });
+        fetch('/cart/add.js',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({items:items})})
+          .then(function(r){ if(!r.ok) throw r; return r.json(); })
+          .then(function(){ window.location.href='/cart'; })
+          .catch(function(){ if(form){ form.submit(); } else { window.location.href='/cart'; } });
+      });
+    });
+    // Initial paint: collapse the rail to the starting color and sync stage.
+    if(colorPos){ renderRail(); filterMobile(); }
+    update();
+  })();
+  </script>
+  {%- if section.settings.show_affirm_line and section.settings.affirm_public_key != blank -%}
+  <script>
+  (function(){
+    /* Affirm promotional-messaging loader (financing widget, not analytics).
+       Guarded so it no-ops if the Affirm app block/embed already loaded it. */
+    if (window.affirm || window._affirm_config) {
+      if (window.affirm && window.affirm.ui && window.affirm.ui.refresh) window.affirm.ui.refresh();
+      return;
+    }
+    window._affirm_config = { public_api_key: {{ section.settings.affirm_public_key | json }}, script: "https://cdn1.affirm.com/js/v2/affirm.js" };
+    (function(m,g,n,d,a,e,h,c){var b=m[n]||{},k=document.createElement(e),p=document.getElementsByTagName(e)[0],l=function(a,b,c){return function(){a[b]._.push([c,arguments])}};b[d]=l(b,d,"set");var f=b[d];b[a]={};b[a]._=[];f._=[];b._=[];b[a][h]=l(b,a,h);b[c]=function(){b._.push([h,arguments])};a=0;for(c="set add save post open empty reset on off trigger ready setProduct".split(" ");a<c.length;a++)f[c[a]]=l(b,d,c[a]);a=0;for(c=["get","token","url","items"];a<c.length;a++)f[c[a]]=function(){};k.async=!0;k.src=g[e];p.parentNode.insertBefore(k,p);delete g[e];f(m[n]);m[n]=b})(window._affirm_config,{script:window._affirm_config.script},"affirm","checkout","ui","script","ready","jsReady");
+  })();
+  </script>
+  {%- endif -%}
+</div>
+{% schema %}
+{
+  "name": "SP-105 PDP · Product",
+  "tag": "section",
+  "max_blocks": 30,
+  "settings": [
+    {
+      "type": "header",
+      "content": "Breadcrumb"
+    },
+    {
+      "type": "text",
+      "id": "bc_home",
+      "label": "Home label",
+      "default": "Home"
+    },
+    {
+      "type": "text",
+      "id": "bc_col",
+      "label": "Collection label",
+      "default": "Triathlon — SP"
+    },
+    {
+      "type": "url",
+      "id": "bc_col_url",
+      "label": "Collection link"
+    },
+    {
+      "type": "header",
+      "content": "Build switcher (groupset)"
+    },
+    {
+      "type": "text",
+      "id": "build_collection",
+      "label": "Collection of SP builds (handle)",
+      "info": "Every product in this collection becomes a switchable build pill; the current product is highlighted. Leave blank to hide.",
+      "default": "sp"
+    },
+    {
+      "type": "text",
+      "id": "build_label",
+      "label": "Switcher label",
+      "default": "Groupset"
+    },
+    {
+      "type": "header",
+      "content": "Title & rating"
+    },
+    {
+      "type": "text",
+      "id": "kicker",
+      "label": "Kicker",
+      "default": "SP Triathlon · Entry build"
+    },
+    {
+      "type": "text",
+      "id": "subtitle",
+      "label": "Subtitle (defaults to product type)",
+      "default": "Carbon triathlon & time-trial bike"
+    },
+    {
+      "type": "text",
+      "id": "rating_stars",
+      "label": "Stars",
+      "default": "★★★★★"
+    },
+    {
+      "type": "text",
+      "id": "rating_value",
+      "label": "Rating value (falls back to reviews.rating metafield)",
+      "default": "4.8"
+    },
+    {
+      "type": "text",
+      "id": "rating_count",
+      "label": "Review count (falls back to reviews.rating_count metafield)"
+    },
+    {
+      "type": "text",
+      "id": "reviews_anchor",
+      "label": "Reviews anchor",
+      "default": "#sppdp-reviews"
+    },
+    {
+      "type": "header",
+      "content": "Price & financing"
+    },
+    {
+      "type": "text",
+      "id": "price_note",
+      "label": "Price note",
+      "default": "USD · $99 flat shipping to the lower 48"
+    },
+    {
+      "type": "range",
+      "id": "affirm_months",
+      "label": "Affirm months (monthly = price ÷ months)",
+      "min": 6,
+      "max": 48,
+      "step": 6,
+      "default": 12
+    },
+    {
+      "type": "text",
+      "id": "affirm_apr",
+      "label": "Affirm APR text",
+      "default": "0% APR"
+    },
+    {
+      "type": "url",
+      "id": "affirm_url",
+      "label": "Affirm prequalify link (static line)"
+    },
+    {
+      "type": "text",
+      "id": "wheel_note",
+      "label": "Wheel-upgrade note",
+      "info": "Shown under the wheel-upgrade options. Per build, set custom.wheel_upgrade_variant (one-click wheel add) and custom.wheel_upgrade_credit (= base wheelset price minus $150); the PDP shows wheel price minus credit, with a matching Save chip. Add custom.wheel_upgrade_variant_2 for a second wheel option. Text-only builds use custom.wheel_upgrade for the callout.",
+      "default": "Discount applied automatically when your bike & wheels are in your cart."
+    },
+    {
+      "type": "checkbox",
+      "id": "show_affirm_line",
+      "label": "Show built-in Affirm line",
+      "info": "Turn off if you add the official Affirm app block (below) so you don't show both.",
+      "default": false
+    },
+    {
+      "type": "text",
+      "id": "affirm_public_key",
+      "label": "Affirm public API key",
+      "info": "Loads Affirm's as-low-as messaging for the built-in line. Leave empty if the Affirm app block/embed already loads affirm.js on this page.",
+      "default": "WSAUD4RQEGCMBW2I"
+    },
+    {
+      "type": "header",
+      "content": "Gallery — caption & hotspots",
+      "info": "Add 'Hotspot' blocks below; set each one's Photo number to place it on that gallery image. Hotspots show only when their photo is on the main stage."
+    },
+    {
+      "type": "textarea",
+      "id": "gallery_caption",
+      "label": "Stage caption",
+      "default": "Hover the numbered points to explore the frame tech."
+    },
+    {
+      "type": "header",
+      "content": "Size calculator"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_size_calc",
+      "label": "Show size calculator",
+      "default": true,
+      "info": "Now sits in the left column under the tech tiles, filling the space beside the buy box."
+    },
+    {
+      "type": "text",
+      "id": "size_calc_cta",
+      "label": "Calculator CTA",
+      "default": "Find your perfect bike size here"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_hotspots",
+      "label": "Show annotation hotspots",
+      "default": true
+    },
+    {
+      "type": "header",
+      "content": "Education detail tiles"
+    },
+    {
+      "type": "image_picker",
+      "id": "edu_1_image",
+      "label": "Tile 1 image"
+    },
+    {
+      "type": "text",
+      "id": "edu_1_title",
+      "label": "Tile 1 title",
+      "default": "Toray T700 carbon"
+    },
+    {
+      "type": "textarea",
+      "id": "edu_1_desc",
+      "label": "Tile 1 text",
+      "default": "Hand-laid layup — the same fiber class as superbikes costing 3× more."
+    },
+    {
+      "type": "image_picker",
+      "id": "edu_2_image",
+      "label": "Tile 2 image"
+    },
+    {
+      "type": "text",
+      "id": "edu_2_title",
+      "label": "Tile 2 title",
+      "default": "SAGS adjustable cockpit"
+    },
+    {
+      "type": "textarea",
+      "id": "edu_2_desc",
+      "label": "Tile 2 text",
+      "default": "140mm fore/aft pad range. Dial your aero fit without a new stem."
+    },
+    {
+      "type": "image_picker",
+      "id": "edu_3_image",
+      "label": "Tile 3 image"
+    },
+    {
+      "type": "text",
+      "id": "edu_3_title",
+      "label": "Tile 3 title",
+      "default": "Race-day storage"
+    },
+    {
+      "type": "textarea",
+      "id": "edu_3_desc",
+      "label": "Tile 3 text",
+      "default": "Down-tube and top-tube mounts for nutrition and tools, built in."
+    },
+    {
+      "type": "header",
+      "content": "Size help & CTA"
+    },
+    {
+      "type": "text",
+      "id": "size_help_label",
+      "label": "Find-your-size link label",
+      "default": "Find your size"
+    },
+    {
+      "type": "url",
+      "id": "size_help_url",
+      "label": "Find-your-size link"
+    },
+    {
+      "type": "text",
+      "id": "cta_prefix",
+      "label": "Add-to-cart label prefix",
+      "default": "Add to cart — "
+    },
+    {
+      "type": "text",
+      "id": "demo_note",
+      "label": "Demo note",
+      "default": "7-day home demo"
+    },
+    {
+      "type": "text",
+      "id": "consult_label",
+      "label": "Consult link label",
+      "default": "Or book a free fit consult"
+    },
+    {
+      "type": "url",
+      "id": "consult_url",
+      "label": "Consult link"
+    },
+    {
+      "type": "header",
+      "content": "Info accordion (below size calculator)"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_accordion",
+      "label": "Show info accordion",
+      "default": true,
+      "info": "Collapsible rows below the size calculator (left column on desktop). Set each row's content to Rich text or Product description, add an optional button, and enable more rows (e.g. Shipping) anytime."
+    },
+    {
+      "type": "header",
+      "content": "Accordion · Row 1"
+    },
+    {
+      "type": "text",
+      "id": "acc1_heading",
+      "label": "Heading",
+      "default": "Description"
+    },
+    {
+      "type": "select",
+      "id": "acc1_content",
+      "label": "Content",
+      "options": [
+        { "value": "none", "label": "Hidden" },
+        { "value": "text", "label": "Rich text" },
+        { "value": "description", "label": "Product description" }
+      ],
+      "default": "description"
+    },
+    {
+      "type": "richtext",
+      "id": "acc1_text",
+      "label": "Rich text",
+      "default": "<p>Add details here.</p>"
+    },
+    {
+      "type": "text",
+      "id": "acc1_btn_label",
+      "label": "Button label"
+    },
+    {
+      "type": "text",
+      "id": "acc1_btn_url",
+      "label": "Button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "acc1_open",
+      "label": "Open by default",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Accordion · Row 2"
+    },
+    {
+      "type": "text",
+      "id": "acc2_heading",
+      "label": "Heading",
+      "default": "Bike Size Guide & Geometry"
+    },
+    {
+      "type": "select",
+      "id": "acc2_content",
+      "label": "Content",
+      "options": [
+        { "value": "none", "label": "Hidden" },
+        { "value": "text", "label": "Rich text" },
+        { "value": "description", "label": "Product description" }
+      ],
+      "default": "text"
+    },
+    {
+      "type": "richtext",
+      "id": "acc2_text",
+      "label": "Rich text",
+      "default": "<p>See full geometry tables and find the right frame size for your body before you buy.</p>"
+    },
+    {
+      "type": "text",
+      "id": "acc2_btn_label",
+      "label": "Button label",
+      "default": "View size guide & geometry"
+    },
+    {
+      "type": "text",
+      "id": "acc2_btn_url",
+      "label": "Button link",
+      "default": "/pages/size-guide",
+      "info": "Paste a URL or path, e.g. /pages/size-guide"
+    },
+    {
+      "type": "checkbox",
+      "id": "acc2_open",
+      "label": "Open by default",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Accordion · Row 3"
+    },
+    {
+      "type": "text",
+      "id": "acc3_heading",
+      "label": "Heading"
+    },
+    {
+      "type": "select",
+      "id": "acc3_content",
+      "label": "Content",
+      "options": [
+        { "value": "none", "label": "Hidden" },
+        { "value": "text", "label": "Rich text" },
+        { "value": "description", "label": "Product description" }
+      ],
+      "default": "none"
+    },
+    {
+      "type": "richtext",
+      "id": "acc3_text",
+      "label": "Rich text",
+      "default": "<p>Add details here.</p>"
+    },
+    {
+      "type": "text",
+      "id": "acc3_btn_label",
+      "label": "Button label"
+    },
+    {
+      "type": "text",
+      "id": "acc3_btn_url",
+      "label": "Button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "acc3_open",
+      "label": "Open by default",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Accordion · Row 4"
+    },
+    {
+      "type": "text",
+      "id": "acc4_heading",
+      "label": "Heading"
+    },
+    {
+      "type": "select",
+      "id": "acc4_content",
+      "label": "Content",
+      "options": [
+        { "value": "none", "label": "Hidden" },
+        { "value": "text", "label": "Rich text" },
+        { "value": "description", "label": "Product description" }
+      ],
+      "default": "none"
+    },
+    {
+      "type": "richtext",
+      "id": "acc4_text",
+      "label": "Rich text",
+      "default": "<p>Add details here.</p>"
+    },
+    {
+      "type": "text",
+      "id": "acc4_btn_label",
+      "label": "Button label"
+    },
+    {
+      "type": "text",
+      "id": "acc4_btn_url",
+      "label": "Button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "acc4_open",
+      "label": "Open by default",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Accordion · Row 5"
+    },
+    {
+      "type": "text",
+      "id": "acc5_heading",
+      "label": "Heading"
+    },
+    {
+      "type": "select",
+      "id": "acc5_content",
+      "label": "Content",
+      "options": [
+        { "value": "none", "label": "Hidden" },
+        { "value": "text", "label": "Rich text" },
+        { "value": "description", "label": "Product description" }
+      ],
+      "default": "none"
+    },
+    {
+      "type": "richtext",
+      "id": "acc5_text",
+      "label": "Rich text",
+      "default": "<p>Add details here.</p>"
+    },
+    {
+      "type": "text",
+      "id": "acc5_btn_label",
+      "label": "Button label"
+    },
+    {
+      "type": "text",
+      "id": "acc5_btn_url",
+      "label": "Button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "acc5_open",
+      "label": "Open by default",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Mobile"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_sticky",
+      "label": "Show persistent mobile add-to-cart bar",
+      "default": true
+    },
+    {
+      "type": "header",
+      "content": "Save your build (Play 3)"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_save_build",
+      "label": "Show 'Save this build / email me the quote'",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "sb_klaviyo_company",
+      "label": "Klaviyo company ID",
+      "default": "YejYTH"
+    },
+    {
+      "type": "text",
+      "id": "sb_klaviyo_list",
+      "label": "Klaviyo list ID for the Saved-Build flow",
+      "info": "List the 'Saved Build' email flow listens on. Leave blank to capture to the CRM only."
+    }
+  ],
+  "blocks": [
+    {
+      "type": "trust",
+      "name": "Trust item",
+      "settings": [
+        {
+          "type": "select",
+          "id": "icon",
+          "label": "Icon",
+          "options": [
+            {
+              "value": "shield-check",
+              "label": "Shield check"
+            },
+            {
+              "value": "bars",
+              "label": "Bars"
+            },
+            {
+              "value": "sliders",
+              "label": "Sliders"
+            },
+            {
+              "value": "warranty",
+              "label": "Warranty"
+            }
+          ],
+          "default": "shield-check"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "Trust point"
+        },
+        {
+          "type": "textarea",
+          "id": "sub",
+          "label": "Subtext"
+        }
+      ]
+    },
+    {
+      "type": "hotspot",
+      "name": "Hotspot",
+      "settings": [
+        {
+          "type": "range",
+          "id": "image_index",
+          "label": "Photo number (which gallery image)",
+          "min": 1,
+          "max": 6,
+          "step": 1,
+          "default": 1
+        },
+        {
+          "type": "text",
+          "id": "label",
+          "label": "Label",
+          "default": "Feature callout"
+        },
+        {
+          "type": "range",
+          "id": "x",
+          "label": "X position %",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "default": 50
+        },
+        {
+          "type": "range",
+          "id": "y",
+          "label": "Y position %",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "default": 50
+        }
+      ]
+    },
+    {
+      "type": "@app"
+    }
+  ],
+  "presets": [
+    {
+      "name": "SP-105 PDP · Product",
+      "blocks": [
+        {
+          "type": "trust",
+          "settings": {
+            "icon": "shield-check",
+            "title": "Designed by ex-Cervélo engineers",
+            "sub": "Kevin Quan, who designed the Cervélo P-Series, drew this frame."
+          }
+        },
+        {
+          "type": "trust",
+          "settings": {
+            "icon": "bars",
+            "title": "Direct-to-consumer pricing",
+            "sub": "No dealer markup. You pay for the bike, not the showroom."
+          }
+        },
+        {
+          "type": "trust",
+          "settings": {
+            "icon": "sliders",
+            "title": "Free fit support & size exchanges",
+            "sub": "Talk to a real fitter before and after you buy. Wrong size? Swap it free."
+          }
+        },
+        {
+          "type": "trust",
+          "settings": {
+            "icon": "warranty",
+            "title": "Lifetime frame warranty + crash replacement",
+            "sub": "Honored directly by us. Damage it in a crash and we replace the frame."
+          }
+        },
+        {
+          "type": "hotspot",
+          "settings": {
+            "image_index": 1,
+            "label": "Kammtail tube shapes — aero without UCI-only weirdness",
+            "x": 34,
+            "y": 58
+          }
+        },
+        {
+          "type": "hotspot",
+          "settings": {
+            "image_index": 1,
+            "label": "Fully internal cable + hose routing",
+            "x": 60,
+            "y": 40
+          }
+        },
+        {
+          "type": "hotspot",
+          "settings": {
+            "image_index": 1,
+            "label": "SAGS cockpit — 140mm of fit adjustment",
+            "x": 78,
+            "y": 30
+          }
+        },
+        {
+          "type": "hotspot",
+          "settings": {
+            "image_index": 2,
+            "label": "TRP Spyre mechanical disc — flat-mount",
+            "x": 32,
+            "y": 66
+          }
+        },
+        {
+          "type": "hotspot",
+          "settings": {
+            "image_index": 2,
+            "label": "12mm thru-axle",
+            "x": 72,
+            "y": 70
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}
+
+

--- a/shopify/snippets/a2-fit-engine.liquid
+++ b/shopify/snippets/a2-fit-engine.liquid
@@ -1,0 +1,715 @@
+{%- comment -%}
+  A2 Bikes — Fit Engine (shared)  ·  Phase 0 of the fit-calculator redesign
+  ---------------------------------------------------------------------------
+  ONE snippet powers the inline fit finder + the slide-in drawer, for BOTH
+  models. Recommendation-first result, branded canvas plot, and the
+  "Requested Fit Results" Klaviyo event (see KLAVIYO-EVENT-SPEC.md).
+
+  Fit MATH is unchanged from the live calcs (deploy11):
+    - Rogue = bar HX/HY model (a2-rogue-fit-calc)
+    - SP    = Pad X/Y model, Metron (105/Rival) or Si013 (Force/Red) cockpit
+             (a2-fit-calculator)
+
+  Usage (from the PDP section):
+    {% render 'a2-fit-engine', model: 'rogue' %}   (or model: 'sp')
+  Reads the current `product` for build handle, price and URL. The top-of-PDP
+  "Find your size" link opens the drawer via window.A2Fit.openDrawer().
+
+  Styling inherits the section's --a2-* tokens; extra shades are derived with
+  color-mix so the widget always matches the surrounding theme. GTM dataLayer
+  only for GA4/Meta (window.a2dl); Klaviyo is the sanctioned direct call.
+{%- endcomment -%}
+
+{%- liquid
+  assign model = model | default: 'rogue'
+  assign build_handle = ''
+  assign cockpit = ''
+  case product.handle
+    when 'sp-shimano-105n'
+      assign build_handle = '105'
+      assign cockpit = 'metron'
+    when 'sp-sram-rival-1'
+      assign build_handle = 'rival'
+      assign cockpit = 'metron'
+    when 'sp-sram-force'
+      assign build_handle = 'force'
+      assign cockpit = 'si013'
+    when 'sp-sram-red-axs'
+      assign build_handle = 'red'
+      assign cockpit = 'si013'
+    when 'rogue-shimano-105'
+      assign build_handle = '105'
+    when 'rogue-rival-axs'
+      assign build_handle = 'rival'
+    when 'rogue-sram-force-etap-axs'
+      assign build_handle = 'force'
+    when 'rogue-sram-red-axs'
+      assign build_handle = 'red'
+  endcase
+  unless build_handle != ''
+    assign build_handle = 'unknown'
+  endunless
+-%}
+<script>
+  window.A2_FIT_CTX = {
+    model: {{ model | json }},
+    build: {{ build_handle | json }},
+    cockpit: {{ cockpit | json }},
+    price: {{ product.price | money | json }},
+    url: {{ product.url | json }},
+    productTitle: {{ product.title | json }},
+    dbUrl: {{ 'a2-bike-db.json' | asset_url | json }}
+  };
+</script>
+
+{% raw %}
+<style>
+  .a2fe{
+    --fe-bg:var(--a2-bg,#ffffff);
+    --fe-ink:var(--a2-fg,#14181d);
+    --fe-accent:var(--a2-accent,#b4122e);
+    --fe-accent-fg:var(--a2-accent-fg,#ffffff);
+    --fe-border:var(--a2-border,rgba(15,20,25,.14));
+    --fe-ink-2:color-mix(in srgb, var(--fe-ink) 60%, var(--fe-bg));
+    --fe-panel:color-mix(in srgb, var(--fe-ink) 4%, var(--fe-bg));
+    --fe-panel-2:color-mix(in srgb, var(--fe-ink) 7%, var(--fe-bg));
+    --fe-border-2:color-mix(in srgb, var(--fe-ink) 22%, var(--fe-bg));
+    --fe-soft:color-mix(in srgb, var(--fe-accent) 8%, var(--fe-bg));
+    --fe-good:#1f8a4c;
+    --fe-shadow:0 1px 2px rgba(15,20,25,.06),0 8px 30px rgba(15,20,25,.08);
+    --fe-disp:var(--a2-font-display,"Bahnschrift","DIN Condensed","Oswald","Arial Narrow",system-ui,sans-serif);
+    --fe-mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --fe-fs:#6b6be6; --fe-fm:#e8527e; --fe-fl:#f29a3c; --fe-fxl:#c3d43a;
+    color:var(--fe-ink);
+  }
+  .a2fe *,.a2fe *::before,.a2fe *::after{ box-sizing:border-box; }
+
+  .a2fe-card-shell{ border:1px solid var(--fe-border); border-radius:16px; background:var(--fe-bg); box-shadow:var(--fe-shadow); overflow:hidden; }
+  .a2fe-head{ display:flex; align-items:baseline; gap:10px; flex-wrap:wrap; padding:16px 20px; border-bottom:1px solid var(--fe-border); background:var(--fe-panel); }
+  .a2fe-kick{ font-family:var(--fe-disp); text-transform:uppercase; letter-spacing:.14em; font-size:.72rem; color:var(--fe-accent); }
+  .a2fe-h{ font-family:var(--fe-disp); font-size:clamp(1.3rem,2.4vw,1.7rem); letter-spacing:.01em; margin:0; text-wrap:balance; }
+  .a2fe-body{ padding:clamp(16px,3vw,26px); }
+
+  .a2fe-field{ display:flex; flex-direction:column; gap:7px; }
+  .a2fe-lbl{ font-size:.82rem; font-weight:600; letter-spacing:.02em; color:var(--fe-ink-2); }
+  .a2fe-in{ font:inherit; color:var(--fe-ink); background:var(--fe-bg); border:1px solid var(--fe-border-2); border-radius:10px; padding:.62em .7em; width:120px; }
+  .a2fe-in-sm{ width:74px; }
+  .a2fe-in:focus-visible{ outline:3px solid var(--fe-accent); outline-offset:1px; }
+  .a2fe-htrow{ display:flex; align-items:center; gap:8px; }
+  .a2fe-htrow span{ color:var(--fe-ink-2); font-size:.9rem; }
+  .a2fe-pills{ display:flex; gap:9px; flex-wrap:wrap; }
+  .a2fe-pill input{ position:absolute; opacity:0; width:1px; height:1px; }
+  .a2fe-pill span{ display:inline-block; padding:.5em 1.05em; border:2px solid var(--fe-border-2); border-radius:999px; cursor:pointer; line-height:1.2; transition:.12s ease; user-select:none; }
+  .a2fe-pill input:checked + span{ border-color:var(--fe-accent); background:var(--fe-accent); color:var(--fe-accent-fg); font-weight:700; }
+  .a2fe-pill input:focus-visible + span{ outline:3px solid var(--fe-accent); outline-offset:2px; }
+
+  .a2fe-btn{ font:inherit; font-family:var(--fe-disp); text-transform:uppercase; letter-spacing:.05em; font-size:1rem; border:2px solid var(--fe-accent); background:var(--fe-accent); color:var(--fe-accent-fg); border-radius:999px; padding:.72em 1.5em; cursor:pointer; transition:filter .12s ease; }
+  .a2fe-btn:hover{ filter:brightness(1.07); }
+  .a2fe-btn:focus-visible{ outline:3px solid var(--fe-ink); outline-offset:2px; }
+  .a2fe-btn-ghost{ background:transparent; color:var(--fe-ink); border-color:var(--fe-border-2); }
+  .a2fe-btn-ghost:hover{ border-color:var(--fe-accent); color:var(--fe-accent); filter:none; }
+  .a2fe-btn-sm{ font-size:.82rem; padding:.5em 1em; }
+  .a2fe-stack{ display:flex; flex-direction:column; gap:18px; }
+  .a2fe-err{ color:var(--fe-accent); font-weight:600; font-size:.9rem; }
+  .a2fe-hide{ display:none !important; }
+
+  .a2fe-lockwrap{ position:relative; }
+  .a2fe-lockwrap.is-locked > :not(.a2fe-lockmsg){ filter:blur(6px); pointer-events:none; user-select:none; }
+  .a2fe-lockwrap:not(.is-locked) .a2fe-lockmsg{ display:none; }
+  .a2fe-lockmsg{ position:absolute; inset:0; z-index:5; display:flex; align-items:center; justify-content:center; text-align:center; font-weight:700; padding:16px; }
+
+  .a2fe-verdict{ display:flex; align-items:center; gap:clamp(14px,3vw,22px); flex-wrap:wrap; }
+  .a2fe-badge{ flex:0 0 auto; width:clamp(76px,15vw,104px); aspect-ratio:1; border-radius:16px; display:flex; align-items:center; justify-content:center; background:var(--fe-accent); color:var(--fe-accent-fg); font-family:var(--fe-disp); font-weight:700; line-height:.9; font-size:clamp(2.6rem,7vw,3.6rem); letter-spacing:.01em; box-shadow:var(--fe-shadow); }
+  .a2fe-vcopy{ flex:1 1 240px; min-width:0; }
+  .a2fe-vkick{ font-family:var(--fe-disp); text-transform:uppercase; letter-spacing:.14em; font-size:.72rem; color:var(--fe-accent); margin-bottom:3px; }
+  .a2fe-vtitle{ font-family:var(--fe-disp); font-size:clamp(1.7rem,4.2vw,2.5rem); line-height:1.02; margin:0 0 6px; text-wrap:balance; }
+  .a2fe-vsub{ color:var(--fe-ink-2); font-size:.98rem; }
+  .a2fe-vreset{ flex:0 0 auto; }
+
+  .a2fe-why{ margin:20px 0 0; font-size:1rem; line-height:1.6; max-width:66ch; }
+  .a2fe-why b{ color:var(--fe-ink); }
+  .a2fe-why-faint{ color:var(--fe-ink-2); font-size:.9rem; margin-top:8px; }
+
+  .a2fe-grid2{ display:grid; grid-template-columns:1fr 1fr; gap:18px; margin-top:22px; }
+  @media (max-width:640px){ .a2fe-grid2{ grid-template-columns:1fr; } }
+  .a2fe-card{ border:1px solid var(--fe-border); border-radius:13px; background:var(--fe-panel); padding:16px 17px; }
+  .a2fe-card-h{ font-family:var(--fe-disp); text-transform:uppercase; letter-spacing:.1em; font-size:.74rem; color:var(--fe-ink-2); margin:0 0 12px; }
+  .a2fe-readout{ display:grid; grid-template-columns:auto 1fr; gap:9px 14px; font-size:.92rem; }
+  .a2fe-readout dt{ color:var(--fe-ink-2); }
+  .a2fe-readout dd{ margin:0; font-family:var(--fe-mono); font-variant-numeric:tabular-nums; text-align:right; }
+  .a2fe-readout dd b{ font-family:inherit; }
+  .a2fe-setup{ margin-top:13px; padding-top:13px; border-top:1px solid var(--fe-border); font-size:.9rem; line-height:1.5; color:var(--fe-ink-2); }
+  .a2fe-setup b{ color:var(--fe-ink); }
+
+  .a2fe-plotwrap{ position:relative; }
+  .a2fe-plot{ width:100%; height:auto; display:block; border-radius:8px; }
+  .a2fe-plotcap{ font-size:.76rem; color:var(--fe-ink-2); margin-top:8px; text-align:center; }
+
+  .a2fe-drop{ margin-top:18px; border:1px solid var(--fe-border); border-left:3px solid var(--fe-accent); border-radius:12px; padding:15px 17px; }
+  .a2fe-drop-top{ display:flex; align-items:baseline; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+  .a2fe-drop-num{ font-family:var(--fe-disp); font-size:1.5rem; }
+  .a2fe-drop-viz{ position:relative; height:44px; margin:14px 0 4px; }
+  .a2fe-drop-line{ position:absolute; left:0; right:0; height:2px; background:var(--fe-border-2); top:50%; }
+  .a2fe-drop-mark{ position:absolute; top:50%; transform:translate(-50%,-50%); text-align:center; }
+  .a2fe-drop-dot{ width:14px; height:14px; border-radius:50%; margin:0 auto 3px; }
+  .a2fe-drop-mark small{ font-size:.7rem; color:var(--fe-ink-2); white-space:nowrap; }
+  .a2fe-drop p{ font-size:.86rem; color:var(--fe-ink-2); margin:9px 0 0; line-height:1.5; }
+
+  .a2fe-email{ margin-top:22px; border:1px solid var(--fe-border); border-radius:13px; background:var(--fe-panel-2); padding:17px 18px; }
+  .a2fe-email-h{ font-family:var(--fe-disp); font-size:1.15rem; margin:0 0 4px; }
+  .a2fe-email-sub{ color:var(--fe-ink-2); font-size:.9rem; margin:0 0 12px; }
+  .a2fe-email-form{ display:flex; gap:10px; flex-wrap:wrap; }
+  .a2fe-email-form .a2fe-in{ flex:1 1 220px; width:auto; }
+  .a2fe-email-done{ border:1px solid var(--fe-good); border-radius:11px; padding:15px 16px; background:color-mix(in srgb, var(--fe-good) 9%, var(--fe-bg)); }
+  .a2fe-email-done h4{ margin:0 0 6px; font-family:var(--fe-disp); }
+  .a2fe-email-done p{ margin:0; color:var(--fe-ink-2); font-size:.92rem; line-height:1.5; }
+  .a2fe-foot{ font-size:.82rem; color:var(--fe-ink-2); margin-top:16px; max-width:70ch; line-height:1.5; }
+
+  .a2fe-typeahead{ position:relative; max-width:340px; }
+  .a2fe-typeahead .a2fe-in{ width:100%; }
+  .a2fe-talist{ position:absolute; top:calc(100% + 4px); left:0; right:0; background:var(--fe-bg); border:1px solid var(--fe-border-2); border-radius:11px; box-shadow:var(--fe-shadow); z-index:6050; max-height:264px; overflow-y:auto; }
+  .a2fe-taitem{ display:block; width:100%; text-align:left; font:inherit; background:none; border:0; border-bottom:1px solid var(--fe-border); padding:10px 13px; cursor:pointer; color:var(--fe-ink); }
+  .a2fe-taitem:last-child{ border-bottom:0; }
+  .a2fe-taitem:hover,.a2fe-taitem:focus-visible{ background:var(--fe-soft); }
+  .a2fe-taitem small{ color:var(--fe-ink-2); display:block; font-size:.78rem; }
+  .a2fe-bikechip{ display:inline-flex; align-items:center; gap:9px; padding:8px 12px; margin-top:2px; border:1.5px solid var(--fe-accent); border-radius:10px; background:var(--fe-soft); font-weight:600; }
+  .a2fe-bikechip small{ color:var(--fe-ink-2); font-weight:400; }
+  .a2fe-bikechip button{ font:inherit; border:0; background:none; color:var(--fe-ink-2); cursor:pointer; font-size:1.1rem; line-height:1; padding:0 2px; }
+  .a2fe-bikechip button:hover{ color:var(--fe-accent); }
+  .a2fe-dbload{ display:flex; align-items:center; gap:10px; color:var(--fe-ink-2); font-size:.9rem; padding:4px 0; }
+  .a2fe-dbload::before{ content:""; width:16px; height:16px; border-radius:50%; flex:0 0 auto; border:2px solid var(--fe-border-2); border-top-color:var(--fe-accent); animation:a2feSpin .7s linear infinite; }
+  @keyframes a2feSpin{ to{ transform:rotate(360deg); } }
+  .a2fe-prevnote{ font-size:.82rem; color:var(--fe-ink-2); }
+  .a2fe-linkbtn{ font:inherit; font-size:inherit; border:0; background:none; color:var(--fe-accent); cursor:pointer; text-decoration:underline; text-underline-offset:3px; padding:0; }
+  .a2fe-ftok{ font-size:.85rem; color:var(--fe-good); font-weight:600; }
+
+  .a2fe-overlay{ position:fixed; inset:0; background:rgba(10,12,15,.5); opacity:0; visibility:hidden; transition:opacity .25s ease,visibility .25s ease; z-index:6000; }
+  .a2fe-overlay.a2fe-open{ opacity:1; visibility:visible; }
+  .a2fe-drawer{ position:fixed; top:0; right:0; height:100%; width:min(430px,100%); background:var(--fe-bg); box-shadow:-12px 0 40px rgba(0,0,0,.28); z-index:6001; transform:translateX(100%); transition:transform .28s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; }
+  .a2fe-drawer.a2fe-open{ transform:none; }
+  .a2fe-drawer-head{ display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--fe-border); background:var(--fe-panel); }
+  .a2fe-drawer-head b{ font-family:var(--fe-disp); text-transform:uppercase; letter-spacing:.08em; }
+  .a2fe-drawer-x{ font:inherit; border:0; background:none; color:var(--fe-ink-2); cursor:pointer; font-size:1.4rem; line-height:1; padding:4px 8px; border-radius:8px; }
+  .a2fe-drawer-x:hover{ color:var(--fe-accent); }
+  .a2fe-drawer-body{ padding:20px 18px; overflow-y:auto; }
+  .a2fe-drawer .a2fe-badge{ width:66px; font-size:2.1rem; border-radius:13px; }
+  .a2fe-drawer .a2fe-vtitle{ font-size:1.5rem; }
+  .a2fe-drawer .a2fe-btn{ width:100%; }
+
+  @media (prefers-reduced-motion:reduce){ .a2fe *{ animation:none !important; transition:none !important; } }
+  @keyframes a2fePop{ 0%{ opacity:0; transform:scale(.88) translateY(6px); } 100%{ opacity:1; transform:none; } }
+  @keyframes a2feRise{ 0%{ opacity:0; transform:translateY(10px); } 100%{ opacity:1; transform:none; } }
+  .a2fe-pop{ animation:a2fePop .45s cubic-bezier(.2,.9,.3,1.2) both; }
+  .a2fe-rise{ animation:a2feRise .4s ease both; }
+  .a2fe-rise2{ animation:a2feRise .4s ease .08s both; }
+  .a2fe-rise3{ animation:a2feRise .4s ease .16s both; }
+  @media (max-width:600px){ .a2fe-htrow label,.a2fe-lbl{ font-size:.8rem; } }
+</style>
+
+<div class="a2fe" id="a2fe-inline"><div class="a2fe-card-shell" data-a2fe-mount="inline"></div></div>
+
+<script>
+if (!window.__a2feInit) {
+  window.__a2feInit = true;
+  var CTX = window.A2_FIT_CTX || { model:"rogue", build:"unknown", cockpit:"", price:"", url:"#", productTitle:"" };
+  var A2FE_GATE = "soft"; // "soft" = blur-lock breakdown+chart until email; "off" = no gating
+
+  /* ===================== MODEL: ROGUE (bar HX/HY) ===================== */
+  var ROGUE_GEO = {
+    S:{name:"Small",reach:378,stack:521,hta:72,stockStem:90,crank:"165",bar:"40 cm",hMin:1600,hMax:1675},
+    M:{name:"Medium",reach:381,stack:535,hta:72,stockStem:90,crank:"170",bar:"42 cm",hMin:1700,hMax:1780},
+    L:{name:"Large",reach:386,stack:550,hta:73,stockStem:100,crank:"172.5",bar:"42 cm",hMin:1800,hMax:1880},
+    XL:{name:"XL",reach:390,stack:567,hta:73,stockStem:110,crank:"175",bar:"44 cm",hMin:1900,hMax:1960}
+  };
+  var ROGUE_STEMS=[70,80,90,100,110,120], ROGUE_ANGLES=[-6,6], ROGUE_SPACERS=[0,5,10,15,20,25,30,35];
+  var ROGUE_ANCHORS=[[1637.5,461.4,554.0],[1740.0,464.4,568.0],[1840.0,479.8,583.4],[1930.0,493.6,602.3]];
+  function rogueBarPos(g,sl,sa,sp){ var h=g.hta*Math.PI/180,t=(90-g.hta+sa)*Math.PI/180;
+    return { hx:g.reach-sp*Math.cos(h)+sl*Math.cos(t), hy:g.stack+sp*Math.sin(h)+sl*Math.sin(t) }; }
+  function rogueArray(){ var a=[]; for(var i=0;i<FRAMES.length;i++){ var g=ROGUE_GEO[FRAMES[i]];
+    for(var j=0;j<ROGUE_STEMS.length;j++) for(var k=0;k<ROGUE_ANGLES.length;k++) for(var m=0;m<ROGUE_SPACERS.length;m++){
+      var p=rogueBarPos(g,ROGUE_STEMS[j],ROGUE_ANGLES[k],ROGUE_SPACERS[m]);
+      a.push({frame:FRAMES[i],stemLen:ROGUE_STEMS[j],stemAngle:ROGUE_ANGLES[k],spacers:ROGUE_SPACERS[m],hx:Math.round(p.hx),hy:Math.round(p.hy),edge:(ROGUE_ANGLES[k]>0?10:0)}); } }
+    return a; }
+  function rogueTarget(height,inseam,posture){ var an=ROGUE_ANCHORS,hx,hy;
+    if(height<=an[0][0]){ var s0=[(an[1][1]-an[0][1])/(an[1][0]-an[0][0]),(an[1][2]-an[0][2])/(an[1][0]-an[0][0])]; hx=an[0][1]+(height-an[0][0])*s0[0]; hy=an[0][2]+(height-an[0][0])*s0[1]; }
+    else if(height>=an[an.length-1][0]){ var n=an.length-1,s1=[(an[n][1]-an[n-1][1])/(an[n][0]-an[n-1][0]),(an[n][2]-an[n-1][2])/(an[n][0]-an[n-1][0])]; hx=an[n][1]+(height-an[n][0])*s1[0]; hy=an[n][2]+(height-an[n][0])*s1[1]; }
+    else { for(var i=1;i<an.length;i++){ if(height<=an[i][0]){ var t=(height-an[i-1][0])/(an[i][0]-an[i-1][0]); hx=an[i-1][1]+t*(an[i][1]-an[i-1][1]); hy=an[i-1][2]+t*(an[i][2]-an[i-1][2]); break; } } }
+    var lr=inseam/height; hx-=(lr-0.47)*350; hy+=(lr-0.47)*250;
+    if(posture==="relaxed"){ hy+=12; hx-=6; } if(posture==="aggressive"){ hy-=12; hx+=6; }
+    return {hx:hx,hy:hy}; }
+  function rogueRecommend(h,i){ var o=FRAMES,idx=-1,b=false,r="in-band";
+    for(var x=0;x<o.length;x++){ var g=ROGUE_GEO[o[x]]; if(h>=g.hMin&&h<=g.hMax){ idx=x; break; } }
+    if(idx===-1){ if(h<ROGUE_GEO[o[0]].hMin)idx=0; else if(h>ROGUE_GEO[o[o.length-1]].hMax)idx=o.length-1;
+      else { for(var j=0;j<o.length-1;j++){ if(h>ROGUE_GEO[o[j]].hMax&&h<ROGUE_GEO[o[j+1]].hMin){ idx=j+1; b=true; r="boundary"; break; } } } }
+    else if(idx<o.length-1){ if(h>=ROGUE_GEO[o[idx]].hMax-20){ idx+=1; b=true; r="boundary"; } else if(i/h>=0.48){ idx+=1; b=true; r="inseam"; } }
+    return {frame:o[idx],idx:idx,between:b,reason:r,fromFrame:b&&idx>0?o[idx-1]:null}; }
+
+  /* ===================== MODEL: SP (Pad X/Y) ===================== */
+  var SP_CFG={
+    metron:{ label:"Vision Metron Alloy (105 / Rival)", sizes:{S:[450.1,552.4],M:[473.0,585.8],L:[495.0,619.8],XL:[517.1,653.7]}, stems:[[0,0,"A2 SP 78mm"],[14.4,3.2,"A2 SP 93mm"],[28.9,6.3,"A2 SP 108mm"]], pads:[-16,-8,0,8,16] },
+    si013:{ label:"Vision Si013 (Force / Red)", sizes:{S:[535.5,579.0],M:[558.5,612.2],L:[581.2,645.8],XL:[603.0,679.1]}, stems:[[0,0,"A2 SP 78mm"],[12.1,3.0,"A2 SP 93mm"],[24.2,5.9,"A2 SP 108mm"]], pads:[-64,-48,-32,-16,0,16,32,48,64] }
+  };
+  var SP_SPACERS=[0,5,10,15,20,25,30,35,40,45,50,55,60,65,70];
+  var SP_AVG_INSEAM={63:29.5,64:30,65:30.5,66:31,67:31.5,68:32,69:32.5,70:33,71:33.5,72:34,73:34.5,74:35,75:35.5,76:36,77:36.5};
+  function spAvgInseam(t){ return SP_AVG_INSEAM[Math.round(t)]||32; }
+  function spArray(cfgKey){ var cfg=SP_CFG[cfgKey],a=[],mSt=0,mPad=0,mSp=SP_SPACERS[SP_SPACERS.length-1];
+    for(var s=0;s<cfg.stems.length;s++){ if(cfg.stems[s][0]>mSt)mSt=cfg.stems[s][0]; }
+    for(var p=0;p<cfg.pads.length;p++){ if(Math.abs(cfg.pads[p])>mPad)mPad=Math.abs(cfg.pads[p]); }
+    for(var i=0;i<FRAMES.length;i++) for(var j=0;j<cfg.stems.length;j++) for(var k=0;k<SP_SPACERS.length;k++) for(var m=0;m<cfg.pads.length;m++){
+      a.push({ frame:FRAMES[i], stem:cfg.stems[j][2], pedSpacers:SP_SPACERS[k], pad:cfg.pads[m],
+        edge:18*(mSp?SP_SPACERS[k]/mSp:0)+10*(mSt?cfg.stems[j][0]/mSt:0)+8*(mPad?Math.abs(cfg.pads[m])/mPad:0),
+        hx:Math.round(cfg.sizes[FRAMES[i]][0]+cfg.stems[j][0]+cfg.pads[m]),
+        hy:Math.round(cfg.sizes[FRAMES[i]][1]+cfg.stems[j][1]+SP_SPACERS[k]) }); }
+    return a; }
+  function spTarget(height,inseam,posture){ var saddle=0.9*inseam;
+    var hx=0.29*height+(0.42-saddle/height)*500, hy=0.35*height-(0.42-saddle/height)*400;
+    if(posture==="relaxed"){ hy+=15; hx-=5; } if(posture==="aggressive"){ hy-=15; hx+=5; }
+    return {hx:hx,hy:hy}; }
+  function spRecommend(t,i){ var bands=[{f:"S",min:63,max:66},{f:"M",min:67,max:70},{f:"L",min:71,max:74},{f:"XL",min:75,max:77}];
+    var d=i-spAvgInseam(t),idx=-1,b=false,r="in-band";
+    for(var x=0;x<bands.length;x++){ if(t>=bands[x].min&&t<=bands[x].max){ idx=x; break; } }
+    if(idx===-1){ if(t<bands[0].min)idx=0; else if(t>bands[bands.length-1].max)idx=bands.length-1;
+      else { for(var j=0;j<bands.length-1;j++){ if(t>bands[j].max&&t<bands[j+1].min){ idx=j+1; b=true; r="boundary"; break; } } } }
+    else if(idx<bands.length-1){ if(t>=bands[idx].max-0.75){ idx+=1; b=true; r="boundary"; } else if(d>=1.5){ idx+=1; b=true; r="inseam"; } }
+    return {frame:bands[idx].f,idx:idx,between:b,reason:r,delta:d,fromFrame:b&&idx>0?bands[idx-1].f:null}; }
+
+  /* ===================== SHARED ===================== */
+  var FRAMES=["S","M","L","XL"], NAMES={S:"Small",M:"Medium",L:"Large",XL:"XL"};
+  var isSP=(CTX.model==="sp");
+
+  var COPY={
+    rogue:{
+      "105":{name:"Rogue 105",hook:"The one that just goes.",evergreen:"Simple, dependable, and ready when you are. The Rogue 105 is our most-ridden all-road build for a reason: Shimano&rsquo;s trusted 105 groupset is the drivetrain that never asks for attention &mdash; no batteries to charge, no apps to pair, just crisp mechanical shifts from the first cold climb to the last gravel mile."},
+      "rival":{name:"Rogue Rival AXS",hook:"Wireless, and wide open.",evergreen:"The Rogue Rival AXS cuts the cables. SRAM&rsquo;s wireless electronic shifting means you tap to shift &mdash; every time, in any weather &mdash; backed by a streamlined 2x drivetrain with a range wide enough for a steep wall and fast enough for the descent that follows."},
+      "force":{name:"Rogue Force AXS",hook:"Red performance, minus the Red price.",evergreen:"The Rogue Force AXS is the build our strongest riders keep choosing: crisp wireless AXS shifting, a lighter and more refined build, and the race-day polish of the top tier &mdash; for meaningfully less than Red. Climb stronger, descend braver, stay comfortable when the ride runs long."},
+      "red":{name:"Rogue Red AXS",hook:"The summit build.",evergreen:"The Rogue Red AXS is the lightest, sharpest, most precise all-road bike we make &mdash; SRAM&rsquo;s flagship Red AXS groupset paired with Zipp 353 NSW carbon wheels. Every gram and every watt is accounted for."}
+    },
+    sp:{
+      "105":{name:"SP 105",hook:"Your first fast.",evergreen:"The SP 105 is our most popular triathlon build and the smartest way into a real race bike. Shimano&rsquo;s trusted 105 mechanical groupset means dependable shifting you never have to think about &mdash; so you can think about your splits instead. Built on the most adjustable tri frame we make, it grows with you from your first sprint to your first 70.3."},
+      "rival":{name:"SP Rival AXS",hook:"Watts, wirelessly.",evergreen:"The SP Rival AXS steps up to SRAM&rsquo;s wireless electronic shifting &mdash; clean, fast, and made for the aero position, where reaching for a lever costs you time and comfort. Streamlined and efficient, it&rsquo;s built for big training blocks and Ironman bike legs where every watt counts. (Pre-orders ship with Zipp 303 S carbon wheels.)"},
+      "force":{name:"SP Force AXS",hook:"The pro&rsquo;s pick.",evergreen:"Our pro and age-group athletes gravitate to the SP Force AXS: near-Red performance without the Red price. Wireless AXS shifting, a lighter and more refined build, and the confidence to race fast in 70.3s and full Ironmans. (Pre-orders ship with Zipp 404 carbon wheels.)"},
+      "red":{name:"SP Red AXS",hook:"Podium spec.",evergreen:"The SP Red AXS is the pinnacle &mdash; SRAM&rsquo;s lightest, most precise Red AXS groupset on Zipp 808 Firecrest carbon wheels, wrapped on the most adjustable aero frame in triathlon. This is the build for athletes racing at the front, chasing PRs, and refusing to leave a single second on the table."}
+    }
+  };
+  function buildCopy(){ var m=COPY[CTX.model]||COPY.rogue; return m[CTX.build] || {name:CTX.productTitle||"this build",hook:"",evergreen:""}; }
+
+  function findCombinations(hx,hy,arr,allowed){
+    var c=arr, fit={userhx:hx,userhy:hy};
+    for(var i=c.length-1;i>=0;i--){ c[i].error=Math.sqrt((c[i].hx-hx)*(c[i].hx-hx)+(c[i].hy-hy)*(c[i].hy-hy)); c[i].score=c[i].error+(c[i].edge||0)+(allowed&&allowed.indexOf(c[i].frame)===-1?9999:0); }
+    fit.options=[c[0],c[1],c[2]];
+    for(var i=c.length-1;i>=0;i--){ if(c[i].score<fit.options[0].score) fit.options[0]=c[i]; }
+    for(var i=c.length-1;i>=0;i--){ if(c[i].score<fit.options[1].score&&c[i].frame!=fit.options[0].frame) fit.options[1]=c[i]; }
+    for(var i=c.length-1;i>=0;i--){ if(c[i].score<fit.options[2].score&&c[i].frame!=fit.options[0].frame&&c[i].frame!=fit.options[1].frame) fit.options[2]=c[i]; }
+    fit.options.sort(function(a,b){return a.score-b.score;});
+    return fit;
+  }
+
+  function compute(heightMM,inseamMM,posture){
+    if(heightMM<1200||heightMM>2200||inseamMM<500||inseamMM>=heightMM) return {bad:true};
+    var totalIn=heightMM/25.4, inseamIn=inseamMM/25.4;
+    var target, recInfo, arr, saddle, drop, cfgKey="";
+    if(isSP){
+      cfgKey=(CTX.cockpit==="si013")?"si013":"metron";
+      target=spTarget(heightMM,inseamMM,posture);
+      recInfo=spRecommend(totalIn,inseamIn);
+      arr=spArray(cfgKey);
+      saddle=0.9*inseamMM;
+    } else {
+      if(heightMM<1575) return {oor:"small"}; if(heightMM>1985) return {oor:"tall"};
+      target=rogueTarget(heightMM,inseamMM,posture);
+      recInfo=rogueRecommend(heightMM,inseamMM);
+      arr=rogueArray();
+      saddle=0.883*inseamMM;
+    }
+    var fit=findCombinations(target.hx,target.hy,arr,[recInfo.frame]);
+    var rec=fit.options[0];
+    if(isSP){ drop=Math.round(saddle-rec.hy); }
+    else { var sv=Math.round(saddle*Math.sin(73.5*Math.PI/180)); drop=sv-rec.hy; }
+    return { fit:fit, rec:rec, recInfo:recInfo, cfgKey:cfgKey, arr:arr, target:target,
+      frame:rec.frame, name:NAMES[rec.frame], heightMM:heightMM, inseamMM:inseamMM, totalIn:totalIn, inseamIn:inseamIn,
+      posture:posture, saddleMM:Math.round(saddle), saddleIn:Math.round(saddle/25.4*10)/10, hx:rec.hx, hy:rec.hy, drop:drop };
+  }
+
+  function posLabel(p){ return p.charAt(0).toUpperCase()+p.slice(1); }
+
+  function whyHtml(r){
+    var ft=Math.floor(r.totalIn/12), inch=Math.round(r.totalIn-ft*12); if(inch>=12){ ft++; inch-=12; }
+    if(isSP){
+      var inseamTxt=(Math.round(r.inseamIn*10)/10)+"&Prime;";
+      var h="<p class='a2fe-why'>At <b>"+ft+"&prime;"+inch+"&Prime;</b> with a <b>"+inseamTxt+"</b> inseam, the <b>"+r.name+"</b> is the frame whose stack and reach land your aerobar pads in the middle of their range &mdash; low enough to get aero, with room to fine-tune fore/aft and height instead of maxing out the stem or spacer stack.";
+      if(r.recInfo.between&&r.recInfo.reason==="boundary"){ h+=" You&rsquo;re right between the "+NAMES[r.recInfo.fromFrame]+" and the "+r.name+", so we size up: a slightly larger frame comes lower and tighter with the stem and pads, but a too-small frame can never be made big enough."; }
+      else if(r.recInfo.between&&r.recInfo.reason==="inseam"){ h+=" Your inseam is long for your height, so we size up to the "+r.name+" for the standover clearance and saddle height your legs want."; }
+      else if(r.recInfo.delta<=-1.5){ h+=" Your inseam runs a little short for your height &mdash; more torso than leg &mdash; which the "+r.name+"&rsquo;s reach suits."; }
+      else if(r.recInfo.delta>=1.5){ h+=" Your inseam is a touch long for your height, so you have plenty of standover on the "+r.name+" and will run a taller saddle."; }
+      else { h+=" Your proportions are about average for your height, so standover, saddle height and reach all land where the "+r.name+" is designed to sit."; }
+      h+="</p><p class='a2fe-why a2fe-why-faint'>Use the Position toggle for more or less aero drop &mdash; and free size exchanges if it&rsquo;s not perfect.</p>";
+      return h;
+    }
+    var h2="<p class='a2fe-why'>At <b>"+ft+"&prime;"+inch+"&Prime;</b>, the <b>"+r.name+"</b> puts the bars where your body wants them &mdash; the standover clearance you need, with room to fine-tune height using the stem and spacers instead of running out of adjustment.";
+    if(r.recInfo.between&&r.recInfo.reason==="boundary"){ h2+=" You&rsquo;re right between the "+NAMES[r.recInfo.fromFrame]+" and the "+r.name+", so we size up: a larger road frame drops easily with the stem and spacers, but a too-small one leaves you cramped and forces a long stem that dulls the steering."; }
+    else if(r.recInfo.between&&r.recInfo.reason==="inseam"){ h2+=" Your legs are long for your height, so the "+r.name+" gives you the standover and saddle height they want."; }
+    else { h2+=" Your proportions land squarely in the "+r.name+"&rsquo;s range."; }
+    h2+="</p><p class='a2fe-why a2fe-why-faint'>Use the Position toggle for a racier or more upright feel &mdash; and free size exchanges if it&rsquo;s not perfect.</p>";
+    return h2;
+  }
+  function setupLine(r){
+    if(isSP){ return "<b>Starting cockpit setup</b><br>Frame: A2 SP "+r.frame+" &middot; "+r.rec.stem+" stem &middot; "+r.rec.pedSpacers+"mm spacers &middot; armrests "+(r.rec.pad>0?"+":"")+r.rec.pad+"mm fore/aft<br>Pad stack / reach: "+r.rec.hy+" / "+r.rec.hx+"mm"; }
+    var stem=r.rec.stemLen+"mm &middot; "+(r.rec.stemAngle<0?"&minus;6&deg;":"+6&deg; (flipped up)"); if(r.rec.stemLen===ROGUE_GEO[r.frame].stockStem) stem+=" &mdash; stock length";
+    return "<b>Starting setup</b><br>Frame: Rogue "+r.name+" &middot; "+stem+" &middot; "+r.rec.spacers+"mm spacers<br>Stock cranks "+ROGUE_GEO[r.frame].crank+"mm &middot; stock bars "+ROGUE_GEO[r.frame].bar+" c-c";
+  }
+  function dropDesc(d){ if(isSP){ if(d>=160)return"a very aggressive, maximally aero position"; if(d>=120)return"an aggressive, aero position"; if(d>=70)return"a balanced position &mdash; aero but sustainable"; if(d>=30)return"a relaxed, comfort-first position"; if(d>=0)return"a very relaxed, comfort-first position"; return"an upright position &mdash; pads above the saddle"; }
+    return d>100?"a sporty, aero position":(d>60?"a balanced, sustainable position":"a relaxed, upright position"); }
+
+  function coordLabels(){ return isSP?["Pad reach (X)","Pad stack (Y)"]:["Bar reach (HX)","Bar stack (HY)"]; }
+
+  /* ---------- previous-bike path (see PREVIOUS-BIKE-SPEC.md) ---------- */
+  var FEEL_LABEL={stretched:"Too stretched",right:"Just right",upright:"Too upright"};
+  var BIKE_DB=null, BIKE_DB_STATE="idle"; // idle | loading | ready | error
+  function loadBikeDB(cb){
+    if(BIKE_DB_STATE==="ready") return cb(true);
+    if(BIKE_DB_STATE==="error") return cb(false);
+    var url=CTX.dbUrl||window.A2_FIT_DB_URL;
+    if(!url){ BIKE_DB_STATE="error"; return cb(false); }
+    BIKE_DB_STATE="loading";
+    fetch(url).then(function(res){ if(!res.ok) throw 0; return res.json(); }).then(function(j){
+      var want=isSP?["tri"]:["road","gravel"];
+      // only entries for this page's discipline, with real per-size geometry
+      BIKE_DB=(j.bikes||[]).filter(function(b){ return want.indexOf(b.type)>=0 && b.sizes && !Array.isArray(b.sizes); });
+      BIKE_DB_STATE = BIKE_DB.length ? "ready" : "error";
+      cb(BIKE_DB_STATE==="ready");
+    }).catch(function(){ BIKE_DB_STATE="error"; cb(false); });
+  }
+
+  /* Previous bike -> target point. Road: reconstruct the bars with typical-
+     setup assumptions (100mm -6deg stem, 20mm spacers). Tri: frame + per-bike
+     pad offset (default +55/+90). Feel pills nudge the target; height still
+     gates the frame (size-band rule). */
+  function computeFromBike(heightMM,entry,sizeLabel,feel){
+    var g=entry.sizes[sizeLabel];
+    if(!g||g.stack==null||g.reach==null) return {bad:true};
+    var totalIn=heightMM/25.4, hx, hy, recInfo, arr, cfgKey="";
+    if(isSP){
+      var po=entry.padOffset||{};
+      hx=g.reach+(po.x!=null?po.x:55);
+      hy=g.stack+(po.y!=null?po.y:90);
+      if(feel==="stretched"){ hx-=5; hy+=15; }
+      if(feel==="upright"){ hx+=5; hy-=15; }
+      recInfo=spRecommend(totalIn,spAvgInseam(totalIn));
+      cfgKey=(CTX.cockpit==="si013")?"si013":"metron";
+      arr=spArray(cfgKey);
+    } else {
+      if(heightMM<1575) return {oor:"small"};
+      if(heightMM>1985) return {oor:"tall"};
+      var hta=entry.hta||73, htaR=hta*Math.PI/180, th=(90-hta-6)*Math.PI/180;
+      hx=g.reach-20*Math.cos(htaR)+100*Math.cos(th);
+      hy=g.stack+20*Math.sin(htaR)+100*Math.sin(th);
+      if(feel==="stretched"){ hx-=6; hy+=12; }
+      if(feel==="upright"){ hx+=6; hy-=12; }
+      recInfo=rogueRecommend(heightMM,0.47*heightMM); // avg proportions for the gate
+      arr=rogueArray();
+    }
+    var fit=findCombinations(hx,hy,arr,[recInfo.frame]);
+    var rec=fit.options[0];
+    return {
+      target:{hx:hx,hy:hy}, fit:fit, rec:rec, recInfo:recInfo, cfgKey:cfgKey, arr:arr,
+      frame:rec.frame, name:NAMES[rec.frame], heightMM:heightMM, totalIn:totalIn, posture:"balanced",
+      noBody:true, prevBike:{brand:entry.brand,model:entry.model,years:entry.years,size:sizeLabel,feel:feel},
+      hx:rec.hx, hy:rec.hy
+    };
+  }
+
+  function prevWhyHtml(r){
+    var pb=r.prevBike, cl=coordLabels();
+    var feelTxt = pb.feel==="stretched" ? "It felt stretched, so we brought your target a touch closer and higher."
+      : pb.feel==="upright" ? "It felt too upright, so we set your target a touch longer and lower &mdash; racier."
+      : "It felt right, so we matched that position as closely as we can.";
+    var where=isSP?"aerobar pads":"bars";
+    var assume=isSP?"Assumes your old bike&rsquo;s stock cockpit and typical pad offsets"
+      :"Assumes a typical 100mm &minus;6&deg; stem with 20mm of spacers on your old bike";
+    return "<p class='a2fe-why'>Your <b>"+pb.brand+" "+pb.model+"</b> in <b>"+esc(pb.size)+"</b> put your "+where+" around <b>"
+      +Math.round(r.target.hx)+" / "+Math.round(r.target.hy)+"&nbsp;mm</b> ("+cl[0].replace(/ \(.*/,"")+" / "+cl[1].replace(/ \(.*/,"")+", from its published geometry). "
+      +feelTxt+" The <b>"+r.name+"</b> reaches that same position with adjustment room to spare &mdash; you're not starting fit from zero, you're starting from a bike you already know.</p>"
+      +"<p class='a2fe-why a2fe-why-faint'>"+assume+" &mdash; confirm with a pro fit. Free size exchanges either way.</p>";
+  }
+
+  /* ---------- branded canvas plot ---------- */
+  function drawPlot(canvas,r){
+    var cs=getComputedStyle(canvas.closest(".a2fe"));
+    var ink=cs.getPropertyValue("--fe-ink").trim(), sub=cs.getPropertyValue("--fe-ink-2").trim(), accent=cs.getPropertyValue("--fe-accent").trim(), border=cs.getPropertyValue("--fe-border-2").trim();
+    var fc={S:cs.getPropertyValue("--fe-fs").trim(),M:cs.getPropertyValue("--fe-fm").trim(),L:cs.getPropertyValue("--fe-fl").trim(),XL:cs.getPropertyValue("--fe-fxl").trim()};
+    var dpr=Math.min(window.devicePixelRatio||1,2), W=canvas.clientWidth||360, H=Math.round(W*0.72);
+    canvas.width=W*dpr; canvas.height=H*dpr; var ctx=canvas.getContext("2d"); ctx.scale(dpr,dpr); ctx.clearRect(0,0,W,H);
+    var padL=44,padR=12,padT=14,padB=34;
+    var xs=r.arr.map(function(p){return p.hx;}).concat([r.target.hx,r.hx]), ys=r.arr.map(function(p){return p.hy;}).concat([r.target.hy,r.hy]);
+    var minX=Math.min.apply(null,xs)-6,maxX=Math.max.apply(null,xs)+6,minY=Math.min.apply(null,ys)-6,maxY=Math.max.apply(null,ys)+6;
+    function X(v){return padL+(v-minX)/(maxX-minX)*(W-padL-padR);} function Y(v){return H-padB-(v-minY)/(maxY-minY)*(H-padT-padB);}
+    ctx.strokeStyle=border; ctx.globalAlpha=.5; ctx.lineWidth=1; ctx.font="10px "+cs.getPropertyValue("--fe-mono"); ctx.fillStyle=sub;
+    for(var gx=0;gx<=4;gx++){ var vx=minX+(maxX-minX)*gx/4,px=X(vx); ctx.beginPath(); ctx.moveTo(px,padT); ctx.lineTo(px,H-padB); ctx.stroke(); ctx.globalAlpha=1; ctx.textAlign="center"; ctx.fillText(Math.round(vx),px,H-padB+15); ctx.globalAlpha=.5; }
+    for(var gy=0;gy<=4;gy++){ var vy=minY+(maxY-minY)*gy/4,py=Y(vy); ctx.beginPath(); ctx.moveTo(padL,py); ctx.lineTo(W-padR,py); ctx.stroke(); ctx.globalAlpha=1; ctx.textAlign="right"; ctx.fillText(Math.round(vy),padL-6,py+3); ctx.globalAlpha=.5; }
+    ctx.globalAlpha=1; ctx.fillStyle=sub; ctx.textAlign="center"; ctx.font="600 10px "+cs.getPropertyValue("--fe-disp");
+    ctx.fillText(isSP?"PAD CENTER X (mm)":"BAR REACH HX (mm)",(padL+W-padR)/2,H-4);
+    ctx.save(); ctx.translate(11,(padT+H-padB)/2); ctx.rotate(-Math.PI/2); ctx.fillText(isSP?"PAD Y (mm)":"BAR STACK HY (mm)",0,0); ctx.restore();
+    r.arr.forEach(function(p){ var on=(p.frame===r.frame); ctx.beginPath(); ctx.arc(X(p.hx),Y(p.hy),on?2.6:1.8,0,7); ctx.fillStyle=fc[p.frame]; ctx.globalAlpha=on?.9:.28; ctx.fill(); });
+    ctx.globalAlpha=1; ctx.beginPath(); ctx.arc(X(r.target.hx),Y(r.target.hy),6,0,7); ctx.lineWidth=2.5; ctx.strokeStyle=ink; ctx.stroke();
+    ctx.beginPath(); ctx.arc(X(r.hx),Y(r.hy),6.5,0,7); ctx.fillStyle=accent; ctx.fill(); ctx.lineWidth=2; ctx.strokeStyle="#fff"; ctx.globalAlpha=.85; ctx.stroke(); ctx.globalAlpha=1;
+  }
+
+  /* ---------- markup ---------- */
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+  function PANEL(compact){ var u=compact?'d':'i';
+    return (compact?'':'<div class="a2fe-head"><span class="a2fe-kick">A2 Fit Finder</span><h2 class="a2fe-h">Which '+(isSP?'SP':'Rogue')+' size am I?</h2></div>')+
+    '<div class="a2fe-body"><div data-view="input" class="a2fe-stack">'+
+      '<div class="a2fe-field"><span class="a2fe-lbl">Start with</span><div class="a2fe-pills" data-f="path">'+
+        '<label class="a2fe-pill"><input type="radio" name="a2fepath-'+u+'" value="measure" checked><span>My measurements</span></label>'+
+        '<label class="a2fe-pill"><input type="radio" name="a2fepath-'+u+'" value="prevbike"><span>A bike I&rsquo;ve owned</span></label>'+
+      '</div><div class="a2fe-ftok a2fe-hide" data-el="ftok"></div></div>'+
+      '<div data-sub="measure" class="a2fe-stack">'+
+        '<div class="a2fe-field"><span class="a2fe-lbl">Height</span><div class="a2fe-htrow"><input class="a2fe-in a2fe-in-sm" data-f="ft" type="number" inputmode="numeric" placeholder="5"> <span>ft</span><input class="a2fe-in a2fe-in-sm" data-f="in" type="number" inputmode="decimal" placeholder="10"> <span>in</span></div></div>'+
+        '<div class="a2fe-field"><span class="a2fe-lbl">Inseam</span><div class="a2fe-htrow"><input class="a2fe-in a2fe-in-sm" data-f="inseam" type="number" inputmode="decimal" placeholder="32"> <span>in</span></div></div>'+
+        '<div class="a2fe-field"><span class="a2fe-lbl">Riding position</span><div class="a2fe-pills" data-f="pos">'+
+          '<label class="a2fe-pill"><input type="radio" name="a2fepos-'+u+'" value="relaxed"><span>Relaxed</span></label>'+
+          '<label class="a2fe-pill"><input type="radio" name="a2fepos-'+u+'" value="balanced" checked><span>Balanced</span></label>'+
+          '<label class="a2fe-pill"><input type="radio" name="a2fepos-'+u+'" value="aggressive"><span>Aggressive</span></label></div></div>'+
+      '</div>'+
+      '<div data-sub="prevbike" class="a2fe-stack a2fe-hide">'+
+        '<div class="a2fe-dbload a2fe-hide" data-el="dbload">Loading bike library&hellip;</div>'+
+        '<div data-el="pbform" class="a2fe-stack a2fe-hide">'+
+          '<div class="a2fe-field"><span class="a2fe-lbl">Your previous bike</span>'+
+            '<div class="a2fe-typeahead"><input class="a2fe-in" data-f="bikeq" type="text" placeholder="Search brand or model&hellip;" autocomplete="off">'+
+            '<div class="a2fe-talist a2fe-hide" data-el="talist"></div></div>'+
+            '<div class="a2fe-bikechip a2fe-hide" data-el="bikechip"></div></div>'+
+          '<div class="a2fe-field a2fe-hide" data-el="sizefield"><span class="a2fe-lbl">Size you rode</span><div class="a2fe-pills" data-f="psize"></div></div>'+
+          '<div class="a2fe-field"><span class="a2fe-lbl">Height</span><div class="a2fe-htrow"><input class="a2fe-in a2fe-in-sm" data-f="pft" type="number" inputmode="numeric" placeholder="5"> <span>ft</span><input class="a2fe-in a2fe-in-sm" data-f="pin" type="number" inputmode="decimal" placeholder="10"> <span>in</span></div></div>'+
+          '<div class="a2fe-field"><span class="a2fe-lbl">How did it fit?</span><div class="a2fe-pills" data-f="feel">'+
+            '<label class="a2fe-pill"><input type="radio" name="a2fefeel-'+u+'" value="stretched"><span>Too stretched</span></label>'+
+            '<label class="a2fe-pill"><input type="radio" name="a2fefeel-'+u+'" value="right" checked><span>Just right</span></label>'+
+            '<label class="a2fe-pill"><input type="radio" name="a2fefeel-'+u+'" value="upright"><span>Too upright</span></label></div></div>'+
+          '<div class="a2fe-prevnote" data-el="prevnote">Don&rsquo;t see your bike? <button class="a2fe-linkbtn" data-el="nobike" type="button">Tell us anyway</button> and use your measurements.</div>'+
+        '</div>'+
+      '</div>'+
+      '<div class="a2fe-err a2fe-hide" data-el="err"></div>'+
+      '<div><button class="a2fe-btn" data-el="go" type="button">Find my fit</button></div>'+
+    '</div><div data-view="result" class="a2fe-hide"></div></div>';
+  }
+
+  function resultHtml(r,compact){
+    var cl=coordLabels();
+    var coordRows='<dt>'+cl[0]+'</dt><dd>'+r.hx+' mm</dd><dt>'+cl[1]+'</dt><dd>'+r.hy+' mm</dd>'+
+      (r.prevBike
+        ? '<dt>Previous bike</dt><dd style="font-family:inherit">'+r.prevBike.brand+' '+r.prevBike.model+' &middot; '+esc(r.prevBike.size)+'</dd><dt>It felt</dt><dd style="font-family:inherit"><b>'+FEEL_LABEL[r.prevBike.feel]+'</b></dd>'
+        : '<dt>Saddle height</dt><dd>'+r.saddleMM+' mm</dd><dt>Position</dt><dd><b>'+posLabel(r.posture)+'</b></dd>');
+    var sub=r.prevBike
+      ? 'Matched from your '+r.prevBike.brand+' '+r.prevBike.model+' ('+esc(r.prevBike.size)+').'
+      : (r.recInfo.between?'Sized up so you have room to dial it in.':'A clean match for your proportions.');
+    var verdict='<div class="a2fe-verdict a2fe-pop"><div class="a2fe-badge">'+r.frame+'</div><div class="a2fe-vcopy"><div class="a2fe-vkick">Your size</div><h3 class="a2fe-vtitle">The '+r.name+'</h3><div class="a2fe-vsub">'+sub+'</div></div><div class="a2fe-vreset"><button class="a2fe-btn a2fe-btn-ghost a2fe-btn-sm" data-el="change" type="button">'+(r.prevBike?'Change my answers':'Change my measurements')+'</button></div></div>';
+    if(compact){ return verdict+'<div class="a2fe-lockwrap" data-el="lockwrap"><div class="a2fe-lockmsg" data-el="lockmsg"><span>🔒 Enter your email to unlock your full fit &amp; setup</span></div><div class="a2fe-rise2"><div class="a2fe-card" style="margin-top:16px"><h4 class="a2fe-card-h">Your fit</h4><dl class="a2fe-readout">'+coordRows+'</dl><div class="a2fe-setup">'+setupLine(r)+'</div></div></div></div>'+emailHtml()+'<div class="a2fe-rise3" style="margin-top:14px"><button class="a2fe-btn a2fe-btn-ghost a2fe-btn-sm" data-el="full" type="button">See the full breakdown &rarr;</button></div>'; }
+    var footRogue='Built on the published Rogue geometry, with a &plusmn;6&deg; stem (70&ndash;120mm) and up to 35mm of spacers. '+(r.noBody?'':'Saddle height (0.883 &times; inseam) is a starting point &mdash; fine-tune on your first rides. ')+'Free size exchanges either way.';
+    var footSP='Built on the A2 SP fit sheets: aerobar Pad&nbsp;X/Y with three SP stems (78&thinsp;/&thinsp;93&thinsp;/&thinsp;108&nbsp;mm), up to 70&nbsp;mm of risers, and pad fore/aft adjustment. '+(r.noBody?'':'Saddle height (0.9 &times; inseam) and the drop are starting points &mdash; confirm with a pro fit. ')+'Free size exchanges either way.';
+    return verdict+'<div class="a2fe-lockwrap" data-el="lockwrap"><div class="a2fe-lockmsg" data-el="lockmsg"><span>🔒 Enter your email to unlock your full fit &amp; setup</span></div>'+(r.prevBike?prevWhyHtml(r):whyHtml(r))+
+      '<div class="a2fe-grid2 a2fe-rise2"><div class="a2fe-card"><h4 class="a2fe-card-h">Your fit &amp; setup</h4><dl class="a2fe-readout">'+coordRows+'</dl><div class="a2fe-setup">'+setupLine(r)+'</div></div>'+
+      '<div class="a2fe-card"><h4 class="a2fe-card-h">Where you land</h4><div class="a2fe-plotwrap"><canvas class="a2fe-plot" data-el="plot"></canvas></div><div class="a2fe-plotcap">Every dot is a frame + stem + spacer'+(isSP?' + pad':'')+' combo. Ring = your target &middot; red = your setup.</div></div></div>'+
+      (r.noBody?'':dropHtml(r))+'</div>'+emailHtml()+'<p class="a2fe-foot">'+(isSP?footSP:footRogue)+'</p>';
+  }
+  function dropHtml(r){
+    var label=isSP?'Saddle-to-pad drop':'Bar drop', near=isSP?'Pads':'Bars', far=isSP?'Saddle':'Saddle top';
+    return '<div class="a2fe-drop a2fe-rise2"><div class="a2fe-drop-top"><div><span class="a2fe-card-h" style="margin:0">'+label+'</span></div><div class="a2fe-drop-num">'+(isSP?'':'&asymp; ')+(r.drop>=0?r.drop:('+'+Math.abs(r.drop)))+' mm</div></div>'+
+      '<div class="a2fe-drop-viz"><div class="a2fe-drop-line"></div><div class="a2fe-drop-mark" style="left:18%"><div class="a2fe-drop-dot" style="background:var(--fe-ink)"></div><small>'+far+' '+r.saddleMM+'</small></div><div class="a2fe-drop-mark" style="left:82%"><div class="a2fe-drop-dot" style="background:var(--fe-accent)"></div><small>'+near+' '+r.hy+'</small></div></div>'+
+      '<p>Your saddle sits about <b>'+Math.abs(r.drop)+' mm '+(r.drop>=0?'above':'below')+'</b> the '+(isSP?'elbow pads':'bars')+' &mdash; '+dropDesc(r.drop)+'. Tune it with the Position toggle, spacers'+(isSP?' or pads':' or a stem flip')+' &mdash; no size change needed.</p></div>';
+  }
+  function emailHtml(){
+    return '<div class="a2fe-email a2fe-rise3"><div data-el="emailForm"><h4 class="a2fe-email-h">Send me my results</h4><p class="a2fe-email-sub">Get your fit numbers, your setup, and this build in your inbox.</p><form class="a2fe-email-form" data-el="ef"><input class="a2fe-in" data-el="emailIn" type="email" placeholder="you@email.com" aria-label="Email"><button class="a2fe-btn" type="submit">Email my fit</button></form><div class="a2fe-err a2fe-hide" data-el="emailErr"></div></div><div class="a2fe-email-done a2fe-hide" data-el="emailDone"></div></div>';
+  }
+
+  /* ---------- Klaviyo event (see KLAVIYO-EVENT-SPEC.md) ---------- */
+  function buildProps(r,email){
+    var b=buildCopy(), cl=coordLabels();
+    var coordsSummary=cl[0]+" "+r.hx+" mm &middot; "+cl[1]+" "+r.hy+" mm";
+    var setupSummary=setupLine(r).replace(/<b>[^<]*<\/b>/,"").replace(/<br\s*\/?>/g," &middot; ").replace(/<[^>]+>/g,"").replace(/^\s*&middot;\s*/,"").replace(/\s+/g," ").trim();
+    var whyText=(r.prevBike?prevWhyHtml(r):whyHtml(r)).replace(/<\/p>\s*<p[^>]*>/g," ").replace(/<[^>]+>/g,"").replace(/\s+/g," ").trim();
+    var props={
+      bike_model:isSP?"SP":"Rogue", build:b.name, build_handle:CTX.build, product_url:CTX.url, price:CTX.price, cockpit:r.cfgKey||"",
+      recommended_size:r.name, size_code:r.frame, riding_position:(r.prevBike?"":posLabel(r.posture)),
+      fit_input_method:(r.prevBike?"previous_bike":"measurements"),
+      coords_summary:coordsSummary, saddle_height_mm:(r.noBody?null:r.saddleMM), saddle_height_in:(r.noBody?null:r.saddleIn), drop_mm:(r.noBody?null:r.drop), setup_summary:setupSummary,
+      subject:"Your A2 "+b.name+" size: the "+r.name, size_headline:"You're a "+r.name+".", build_hook:b.hook, why_text:whyText, build_blurb:b.evergreen, cta_label:"Build your "+b.name+" →"
+    };
+    if(isSP){ props.pad_reach_x_mm=r.hx; props.pad_stack_y_mm=r.hy; props.pad_offset_mm=r.rec.pad; props.stem=r.rec.stem; props.spacers_mm=r.rec.pedSpacers; }
+    else { props.bar_reach_hx_mm=r.hx; props.bar_stack_hy_mm=r.hy; props.stem=r.rec.stemLen+"mm "+(r.rec.stemAngle<0?"-6":"+6"); props.spacers_mm=r.rec.spacers; }
+    if(r.prevBike){
+      props.previous_bike_brand=r.prevBike.brand;
+      props.previous_bike_model=r.prevBike.model;
+      props.previous_bike_year_range=r.prevBike.years?(r.prevBike.years[0]+"-"+r.prevBike.years[1]):"";
+      props.previous_bike_size=r.prevBike.size;
+      props.previous_bike_feel=FEEL_LABEL[r.prevBike.feel];
+    }
+    if(r.freetext){ props.previous_bike_freetext=r.freetext; }
+    return props;
+  }
+  function sendFit(r,email,scope){
+    var props=buildProps(r,email), sent=false;
+    try { if (typeof window.a2_identify === "function") window.a2_identify(email, "fit_calculator"); } catch(e){}
+    try{
+      if(window.klaviyo && typeof window.klaviyo.identify==="function"){
+        // Await identify so the event attaches to the ENTERED email, not the
+        // browser's previously-cookied Klaviyo identity (else a returning visitor's
+        // result mis-attributes to their old profile).
+        var _track=function(){ try{ window.klaviyo.track("Requested Fit Results",props); }catch(e){} };
+        try{ var _id=window.klaviyo.identify({email:email}); (_id&&typeof _id.then==="function")?_id.then(_track,_track):_track(); }catch(e){ _track(); }
+        sent=true;
+      }
+      else if(window._learnq){ window._learnq.push(["identify",{"$email":email}]); window._learnq.push(["track","Requested Fit Results",props]); sent=true; }
+    }catch(e){ /* swallow — never break the page over analytics */ }
+    if(!sent && window.console){ console.warn("[a2-fit] Klaviyo onsite object not found — event not sent. Enable Klaviyo.js on the theme.", props); }
+    if(window.a2dl){ window.a2dl("fit_results_email",{ bike_model:props.bike_model, build:props.build_handle, size:props.size_code }); }
+    var form=scope.querySelector('[data-el="emailForm"]'), done=scope.querySelector('[data-el="emailDone"]');
+    form.classList.add("a2fe-hide"); done.classList.remove("a2fe-hide");
+    var lockwrap=scope.querySelector('[data-el="lockwrap"]'); if(lockwrap) lockwrap.classList.remove("is-locked");
+    done.innerHTML='<h4>On its way to '+esc(email)+' &#10003;</h4><p>Your '+r.name+' fit and the '+esc(buildCopy().name)+' are headed to your inbox. Didn&rsquo;t get it? Check spam, or reply to any A2 email and our fit team will help.</p>';
+  }
+
+  /* ---------- panel lifecycle ---------- */
+  function initPanel(root,opts){
+    var compact=!!opts.compact;
+    root.innerHTML=PANEL(compact);
+    var inputView=root.querySelector('[data-view="input"]'), resultView=root.querySelector('[data-view="result"]');
+    var go=root.querySelector('[data-el="go"]'), err=root.querySelector('[data-el="err"]');
+    function fail(m){ err.textContent=m; err.classList.remove("a2fe-hide"); }
+    function showResult(){ inputView.classList.add("a2fe-hide"); resultView.classList.remove("a2fe-hide"); if(opts.onResult) opts.onResult(); }
+    function showInput(){ resultView.classList.add("a2fe-hide"); inputView.classList.remove("a2fe-hide"); }
+    function wireChange(){ var c=resultView.querySelector('[data-el="change"]'); if(c) c.addEventListener("click",showInput); }
+
+    /* ---- previous-bike path wiring ---- */
+    var sel={bike:null}, freetext="";
+    var subMeasure=root.querySelector('[data-sub="measure"]'), subPrev=root.querySelector('[data-sub="prevbike"]');
+    var dbload=root.querySelector('[data-el="dbload"]'), pbform=root.querySelector('[data-el="pbform"]');
+    var bikeq=root.querySelector('[data-f="bikeq"]'), talist=root.querySelector('[data-el="talist"]');
+    var bikechip=root.querySelector('[data-el="bikechip"]'), sizefield=root.querySelector('[data-el="sizefield"]');
+    function activePath(){ return (root.querySelector('[data-f="path"] input:checked')||{}).value||"measure"; }
+    function switchToMeasure(){ var m=root.querySelector('[data-f="path"] input[value="measure"]'); if(m){ m.checked=true; m.dispatchEvent(new Event("change")); } }
+    root.querySelectorAll('[data-f="path"] input').forEach(function(radio){
+      radio.addEventListener("change",function(){
+        var prev=(this.value==="prevbike");
+        subMeasure.classList.toggle("a2fe-hide",prev); subPrev.classList.toggle("a2fe-hide",!prev);
+        err.classList.add("a2fe-hide");
+        if(prev&&BIKE_DB_STATE!=="ready"){
+          dbload.classList.remove("a2fe-hide");
+          loadBikeDB(function(ok){
+            dbload.classList.add("a2fe-hide");
+            if(ok){ pbform.classList.remove("a2fe-hide"); if(bikeq) bikeq.focus(); }
+            else { fail("Our bike library isn't available right now - use your measurements instead."); switchToMeasure(); }
+          });
+        } else if(prev){ pbform.classList.remove("a2fe-hide"); }
+      });
+    });
+    function taRender(matches){
+      if(!matches.length){ talist.classList.add("a2fe-hide"); talist.innerHTML=""; return; }
+      talist.innerHTML=matches.slice(0,8).map(function(b){
+        return '<button type="button" class="a2fe-taitem" data-i="'+BIKE_DB.indexOf(b)+'">'+b.brand+' '+b.model+'<small>'+(b.years?b.years[0]+'&ndash;'+b.years[1]:'')+' &middot; '+(b.type==="gravel"?"Gravel":(b.type==="tri"?"Tri":"Road"))+'</small></button>';
+      }).join("");
+      talist.classList.remove("a2fe-hide");
+    }
+    function selectBike(b){
+      sel.bike=b; talist.classList.add("a2fe-hide"); bikeq.value="";
+      bikeq.parentNode.classList.add("a2fe-hide");
+      bikechip.classList.remove("a2fe-hide");
+      bikechip.innerHTML=b.brand+' '+b.model+' <small>'+(b.years?b.years[0]+'&ndash;'+b.years[1]:'')+'</small><button type="button" aria-label="Clear bike" data-el="clearbike">&times;</button>';
+      bikechip.querySelector('[data-el="clearbike"]').addEventListener("click",function(){
+        sel.bike=null; bikechip.classList.add("a2fe-hide"); bikeq.parentNode.classList.remove("a2fe-hide");
+        sizefield.classList.add("a2fe-hide"); bikeq.focus();
+      });
+      var u=(compact?'d':'i');
+      root.querySelector('[data-f="psize"]').innerHTML=Object.keys(b.sizes).map(function(sz){
+        return '<label class="a2fe-pill"><input type="radio" name="a2fepsize-'+u+'" value="'+esc(sz)+'"><span>'+esc(sz)+'</span></label>';
+      }).join("");
+      sizefield.classList.remove("a2fe-hide");
+      (window.dataLayer=window.dataLayer||[]).push({event:"fit_prev_bike_selected",brand:b.brand,model:b.model,build:CTX.build,bike_model:isSP?"SP":"Rogue"});
+    }
+    if(bikeq){
+      bikeq.addEventListener("input",function(){
+        var q=this.value.trim().toLowerCase();
+        if(!q||!BIKE_DB){ talist.classList.add("a2fe-hide"); return; }
+        taRender(BIKE_DB.filter(function(b){ var n=(b.brand+" "+b.model).toLowerCase();
+          return q.split(/\s+/).every(function(t){ return n.indexOf(t)>=0; }); }));
+      });
+      bikeq.addEventListener("blur",function(){ setTimeout(function(){ talist.classList.add("a2fe-hide"); },160); });
+      talist.addEventListener("mousedown",function(e){ var it=e.target.closest(".a2fe-taitem"); if(it) selectBike(BIKE_DB[+it.getAttribute("data-i")]); });
+    }
+    var nobike=root.querySelector('[data-el="nobike"]');
+    if(nobike) nobike.addEventListener("click",function(){
+      var note=root.querySelector('[data-el="prevnote"]');
+      note.innerHTML='<div class="a2fe-htrow" style="margin-top:4px"><input class="a2fe-in" data-f="ftxt" type="text" placeholder="e.g. 2017 Fuji Norcom, 55" style="width:230px"> <button class="a2fe-btn a2fe-btn-ghost a2fe-btn-sm" data-el="ftsave" type="button">Save</button></div>';
+      note.querySelector('[data-el="ftsave"]').addEventListener("click",function(){
+        freetext=(note.querySelector('[data-f="ftxt"]').value||"").trim();
+        var ftok=root.querySelector('[data-el="ftok"]');
+        if(freetext){ ftok.textContent='Saved — we’ll include “'+freetext+'” with your results.'; ftok.classList.remove("a2fe-hide"); }
+        switchToMeasure();
+      });
+    });
+
+    function finish(r){
+      if(r.bad) return fail("Those numbers look off - double-check your inputs.");
+      if(r.oor){ resultView.innerHTML='<div class="a2fe-verdict"><div class="a2fe-vcopy"><h3 class="a2fe-vtitle">Let&rsquo;s talk it through</h3><div class="a2fe-vsub">You&rsquo;re at the '+(r.oor==="small"?"small":"tall")+' end of the range &mdash; our fit team will find a setup that works. <a href="/pages/contact-a2-bikes">Talk to a fitter &rarr;</a></div></div><div class="a2fe-vreset"><button class="a2fe-btn a2fe-btn-ghost a2fe-btn-sm" data-el="change" type="button">Change my answers</button></div></div>'; showResult(); wireChange(); return; }
+      r.freetext=freetext||"";
+      resultView.innerHTML=resultHtml(r,compact); showResult(); wireResult(r);
+      (window.dataLayer=window.dataLayer||[]).push({event:"fit_calculator_result",recommended_frame:r.frame,build:CTX.build,bike_model:isSP?"SP":"Rogue",fit_input_method:(r.prevBike?"previous_bike":"measurements")});
+    }
+
+    go.addEventListener("click",function(){
+      if(activePath()==="prevbike"){
+        if(BIKE_DB_STATE!=="ready") return;
+        if(!sel.bike) return fail("Pick your previous bike — or switch to your measurements.");
+        var sz=(root.querySelector('[data-f="psize"] input:checked')||{}).value;
+        if(!sz) return fail("Pick the size you rode.");
+        var pft=parseFloat(root.querySelector('[data-f="pft"]').value), pin=parseFloat(root.querySelector('[data-f="pin"]').value);
+        if(isNaN(pft)&&isNaN(pin)) return fail("Enter your height (feet and inches).");
+        err.classList.add("a2fe-hide");
+        var hMM=((isNaN(pft)?0:pft)*12+(isNaN(pin)?0:pin))*25.4;
+        if(hMM<1200||hMM>2200) return fail("That height looks off - double-check it.");
+        var feel=(root.querySelector('[data-f="feel"] input:checked')||{}).value||"right";
+        finish(computeFromBike(hMM,sel.bike,sz,feel));
+        return;
+      }
+      var ft=parseFloat(root.querySelector('[data-f="ft"]').value), inch=parseFloat(root.querySelector('[data-f="in"]').value), inseamIn=parseFloat(root.querySelector('[data-f="inseam"]').value);
+      var pos=(root.querySelector('[data-f="pos"] input:checked')||{}).value||"balanced";
+      if(isNaN(ft)&&isNaN(inch)) return fail("Enter your height (feet and inches).");
+      if(isNaN(inseamIn)) return fail("Enter your inseam in inches.");
+      err.classList.add("a2fe-hide");
+      var heightMM=((isNaN(ft)?0:ft)*12+(isNaN(inch)?0:inch))*25.4, inseamMM=inseamIn*25.4;
+      finish(compute(heightMM,inseamMM,pos));
+    });
+    function wireResult(r){
+      wireChange();
+      if(A2FE_GATE==="soft"){ var lockwrap=resultView.querySelector('[data-el="lockwrap"]'); if(lockwrap) lockwrap.classList.add("is-locked"); }
+      var plot=resultView.querySelector('[data-el="plot"]');
+      if(plot){ requestAnimationFrame(function(){ drawPlot(plot,r); }); try{ new ResizeObserver(function(){ drawPlot(plot,r); }).observe(plot); }catch(e){} }
+      var full=resultView.querySelector('[data-el="full"]');
+      if(full) full.addEventListener("click",function(){ closeDrawer(); var el=document.getElementById("a2fe-inline"); if(el) el.scrollIntoView({behavior:"smooth"}); });
+      var ef=resultView.querySelector('[data-el="ef"]');
+      if(ef) ef.addEventListener("submit",function(e){ e.preventDefault(); var input=resultView.querySelector('[data-el="emailIn"]'), eErr=resultView.querySelector('[data-el="emailErr"]'); var email=(input.value||"").trim();
+        if(!email||email.indexOf("@")<1){ eErr.textContent="Enter a valid email address."; eErr.classList.remove("a2fe-hide"); return; } eErr.classList.add("a2fe-hide"); sendFit(r,email,resultView); });
+    }
+    return { reset:showInput };
+  }
+
+  /* ---------- drawer (injected once) ---------- */
+  var drawerEl, overlayEl;
+  function ensureDrawer(){
+    if(drawerEl) return;
+    overlayEl=document.createElement("div"); overlayEl.className="a2fe-overlay";
+    drawerEl=document.createElement("aside"); drawerEl.className="a2fe a2fe-drawer"; drawerEl.setAttribute("aria-hidden","true"); drawerEl.setAttribute("aria-label","Find your size");
+    drawerEl.innerHTML='<div class="a2fe-drawer-head"><b>Find your size</b><button class="a2fe-drawer-x" data-el="x" aria-label="Close">&times;</button></div><div class="a2fe-drawer-body" data-a2fe-mount="drawer"></div>';
+    document.body.appendChild(overlayEl); document.body.appendChild(drawerEl);
+    overlayEl.addEventListener("click",closeDrawer);
+    drawerEl.querySelector('[data-el="x"]').addEventListener("click",closeDrawer);
+    document.addEventListener("keydown",function(e){ if(e.key==="Escape") closeDrawer(); });
+  }
+  function openDrawer(){ ensureDrawer(); initPanel(drawerEl.querySelector('[data-a2fe-mount="drawer"]'),{compact:true}); overlayEl.classList.add("a2fe-open"); drawerEl.classList.add("a2fe-open"); drawerEl.setAttribute("aria-hidden","false"); var f=drawerEl.querySelector('[data-f="ft"]'); if(f) f.focus(); }
+  function closeDrawer(){ if(!drawerEl) return; overlayEl.classList.remove("a2fe-open"); drawerEl.classList.remove("a2fe-open"); drawerEl.setAttribute("aria-hidden","true"); }
+
+  /* ---------- boot ---------- */
+  var inlineMount=document.querySelector('[data-a2fe-mount="inline"]');
+  if(inlineMount) initPanel(inlineMount,{compact:false});
+  window.A2Fit={ openDrawer:openDrawer, closeDrawer:closeDrawer };
+}
+</script>
+{% endraw %}

--- a/shopify/snippets/a2-restock-alert.liquid
+++ b/shopify/snippets/a2-restock-alert.liquid
@@ -1,0 +1,234 @@
+{%- comment -%}
+  A2 Bikes — "new color drop" teaser for (near) sold-out SP PDPs.
+
+  A brand-accurate, self-contained signup card: ink spotlight panel, crimson
+  (#b4122e) accents, condensed display type — matches the SP PDP, NOT the LP
+  teal palette. The hero graphic is a strip of the real SP colorway swatches
+  ending in a pulsing crimson "?" mystery chip (a new colorway, unrevealed).
+
+  NOT a pre-order and makes no dated promise: email only, no cart/reserve, and
+  "we'll tell you when it drops" is a commitment to notify, not to deliver.
+
+  Wiring: posts to Klaviyo via assets/a2-lp.js (event-delegated submit on
+  form[data-a2-klaviyo-form]; needs data-a2-company / -list / -event / -source /
+  -success, an input[type=email], optional [data-a2-hp] honeypot, [data-a2-msg]).
+  Klaviyo profile properties captured on signup (segmentable, no hard question):
+    - "SP Restock Interest" = product title (data-a2-props, from PDP context)
+    - "SP Restock Size"     = optional size pick ([data-a2-prop] radio group)
+  a2-lp.js merges data-a2-props (static JSON) with any [data-a2-prop] field.
+  a2-lp.js must be loaded on the product template. No a2-lp.css dependency —
+  all styling is inlined and scoped to .a2-drop.
+
+  Renders ONLY when product.metafields.custom.restock_alert (boolean) is true —
+  an explicit owner-controlled per-product toggle (the two live SP builds still
+  carry 1–2 stray units, so we do NOT gate on product.available). Flip it off
+  once the drop is live.
+
+  Copy is metafield-driven (Admin → product → Metafields), with defaults:
+    custom.restock_alert    (boolean)  master on/off — required true to show
+    custom.restock_eyebrow  (text)     default 'New colorways · late summer'
+    custom.restock_heading  (text)     default 'Something new is on the way'
+    custom.restock_body     (text)     default new-colorway tease line
+
+  Klaviyo: company YejYTH · list TpVuRM ("SP Drop — Notify Me (Late Summer 2026)").
+{%- endcomment -%}
+{%- assign _p = product -%}
+{%- if _p.metafields.custom.restock_alert -%}
+  {%- assign _eyebrow = _p.metafields.custom.restock_eyebrow | default: 'New colorways · late summer' -%}
+  {%- assign _heading = _p.metafields.custom.restock_heading | default: 'Something new is on the way' -%}
+  {%- assign _body = _p.metafields.custom.restock_body | default: 'New SP colorways arrive late summer. Want first look? Drop your email and we’ll tell you the moment they’re live.' -%}
+  {%- assign _sizes = '' -%}
+  {%- for opt in _p.options_with_values -%}
+    {%- assign _optname = opt.name | downcase -%}
+    {%- if _optname == 'size' -%}{%- assign _sizes = opt.values -%}{%- endif -%}
+  {%- endfor -%}
+  {%- if _sizes == blank -%}{%- assign _sizes = 'Small,Medium,Large,XL' | split: ',' -%}{%- endif -%}
+  <style>
+    .a2-drop{
+      --drop-accent:#b4122e; --drop-accent-2:#e5322b; --drop-ink:#12161b;
+      --drop-fg:#f6f8fa; --drop-muted:rgba(246,248,250,.66); --drop-line:rgba(246,248,250,.14);
+      --drop-font:"Bahnschrift","DIN Condensed","Oswald","Arial Narrow",system-ui,sans-serif;
+      margin:18px 0 6px;
+    }
+    .a2-drop *{ box-sizing:border-box; }
+    .a2-drop__card{
+      position:relative; overflow:hidden; isolation:isolate;
+      border-radius:16px; padding:clamp(18px,3.4vw,26px);
+      background:
+        radial-gradient(120% 90% at 100% 0%, rgba(180,18,46,.30), transparent 55%),
+        linear-gradient(158deg,#1b2129 0%, #12161b 60%, #0e1216 100%);
+      border:1px solid var(--drop-line);
+      box-shadow:0 18px 40px -22px rgba(0,0,0,.7);
+      color:var(--drop-fg);
+    }
+    .a2-drop__glow{
+      position:absolute; z-index:-1; top:-40%; right:-25%; width:70%; height:120%;
+      background:radial-gradient(closest-side, rgba(229,50,43,.35), transparent 70%);
+      filter:blur(14px); animation:a2dropGlow 6s ease-in-out infinite;
+    }
+    /* Colorway swatch strip — real SP gradients + a mystery "?" chip */
+    .a2-drop__chips{ position:relative; display:flex; gap:8px; margin-bottom:16px; overflow:hidden; }
+    .a2-drop__chip{
+      flex:1 1 0; min-width:0; height:38px; border-radius:9px; background:var(--c,#333);
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.10), 0 4px 10px -6px rgba(0,0,0,.8);
+    }
+    .a2-drop__chip--mystery{
+      display:flex; align-items:center; justify-content:center;
+      background:linear-gradient(150deg,#b4122e,#7d0d20);
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.28), 0 0 0 0 rgba(229,50,43,.55);
+      font:800 1.1rem/1 var(--drop-font); color:#fff; letter-spacing:.02em;
+      animation:a2dropPulse 2.4s ease-in-out infinite;
+    }
+    .a2-drop__sweep{
+      position:absolute; inset:0; pointer-events:none;
+      background:linear-gradient(105deg,transparent 30%, rgba(255,255,255,.22) 48%, transparent 66%);
+      transform:translateX(-120%); animation:a2dropSweep 3.6s ease-in-out infinite;
+    }
+    .a2-drop__kicker{
+      display:flex; align-items:center; gap:8px; margin:0 0 9px;
+      font:700 .72rem/1 var(--drop-font); letter-spacing:.16em; text-transform:uppercase;
+      color:#ff5a68;
+    }
+    .a2-drop__dot{
+      width:8px; height:8px; border-radius:50%; background:var(--drop-accent-2);
+      box-shadow:0 0 0 0 rgba(229,50,43,.6); animation:a2dropPulse 2s ease-in-out infinite;
+    }
+    .a2-drop__title{
+      margin:0 0 8px; font-family:var(--drop-font); font-weight:700;
+      font-size:clamp(1.65rem,5.2vw,2.15rem); line-height:1.02; letter-spacing:.005em; color:#fff;
+    }
+    .a2-drop__body{ margin:0 0 16px; font-size:.98rem; line-height:1.5; color:var(--drop-muted); max-width:44ch; }
+    .a2-drop__form{ margin:0; }
+    .a2-drop__sizes{ border:0; padding:0; margin:0 0 13px; display:flex; flex-wrap:wrap; align-items:center; gap:7px; }
+    .a2-drop__sizeslabel{ padding:0; margin:0 3px 0 0; font:700 .7rem/1 var(--drop-font); letter-spacing:.12em; text-transform:uppercase; color:var(--drop-muted); }
+    .a2-drop__sizeslabel span{ font-weight:400; letter-spacing:.02em; text-transform:none; opacity:.75; }
+    .a2-drop__sizepill{ display:inline-flex; align-items:center; justify-content:center; min-width:38px; height:32px; padding:0 11px; border-radius:9px; border:1px solid var(--drop-line); background:rgba(255,255,255,.04); color:var(--drop-fg); font-size:.85rem; font-weight:600; cursor:pointer; transition:border-color .12s, background .12s, transform .08s; }
+    .a2-drop__sizepill:hover{ border-color:rgba(246,248,250,.42); }
+    .a2-drop__sizepill:active{ transform:scale(.96); }
+    .a2-drop__sizeradio:checked + .a2-drop__sizepill{ background:var(--drop-accent); border-color:var(--drop-accent); color:#fff; }
+    .a2-drop__sizeradio:focus-visible + .a2-drop__sizepill{ outline:2px solid #fff; outline-offset:2px; }
+    .a2-drop__field{ display:flex; gap:8px; flex-wrap:wrap; }
+    .a2-drop__input{
+      flex:1 1 190px; min-width:0; height:48px; padding:0 15px;
+      border-radius:11px; border:1px solid var(--drop-line);
+      background:rgba(255,255,255,.05); color:#fff; font-size:1rem; font-family:inherit;
+      transition:border-color .15s, box-shadow .15s, background .15s;
+    }
+    .a2-drop__input::placeholder{ color:rgba(246,248,250,.42); }
+    .a2-drop__input:focus{
+      outline:none; border-color:var(--drop-accent-2); background:rgba(255,255,255,.08);
+      box-shadow:0 0 0 3px rgba(229,50,43,.28);
+    }
+    .a2-drop__btn{
+      position:relative; overflow:hidden; flex:0 0 auto; height:48px; padding:0 20px;
+      border:0; border-radius:11px; cursor:pointer; white-space:nowrap;
+      display:inline-flex; align-items:center; gap:8px;
+      background:linear-gradient(160deg,var(--drop-accent-2),var(--drop-accent));
+      color:#fff; font:700 .92rem/1 var(--drop-font); letter-spacing:.06em; text-transform:uppercase;
+      box-shadow:0 10px 22px -10px rgba(180,18,46,.9);
+      transition:transform .12s ease, filter .15s ease, box-shadow .15s ease;
+    }
+    .a2-drop__btn svg{ width:15px; height:15px; transition:transform .18s ease; }
+    .a2-drop__btn:hover{ transform:translateY(-1px); filter:brightness(1.07); box-shadow:0 14px 26px -10px rgba(180,18,46,1); }
+    .a2-drop__btn:hover svg{ transform:translateX(3px); }
+    .a2-drop__btn:active{ transform:translateY(0); }
+    .a2-drop__btn:focus-visible{ outline:2px solid #fff; outline-offset:2px; }
+    .a2-drop__btn::after{
+      content:""; position:absolute; inset:0; transform:translateX(-120%);
+      background:linear-gradient(105deg,transparent 35%, rgba(255,255,255,.35) 50%, transparent 65%);
+      animation:a2dropSweep 3.6s ease-in-out infinite 1.2s;
+    }
+    .a2-drop__msg{ margin:10px 0 0; font-size:.9rem; min-height:1.1em; }
+    .a2-drop__msg[data-state="ok"]{ color:#6ee7a8; }
+    .a2-drop__msg[data-state="error"]{ color:#ff8a8a; }
+    .a2-drop__fine{ margin:11px 0 0; font-size:.76rem; color:rgba(246,248,250,.5); }
+    .a2-drop__fine svg{ width:12px; height:12px; vertical-align:-1px; margin-right:5px; opacity:.7; }
+    .a2-drop__hp{ position:absolute; left:-9999px; width:1px; height:1px; overflow:hidden; }
+    .a2-drop__sr{ position:absolute; width:1px; height:1px; margin:-1px; padding:0; overflow:hidden; clip:rect(0 0 0 0); border:0; }
+    @keyframes a2dropSweep{ 0%{transform:translateX(-120%);} 55%,100%{transform:translateX(120%);} }
+    @keyframes a2dropPulse{ 0%,100%{box-shadow:0 0 0 0 rgba(229,50,43,.55);} 50%{box-shadow:0 0 0 7px rgba(229,50,43,0);} }
+    @keyframes a2dropGlow{ 0%,100%{opacity:.7;} 50%{opacity:1;} }
+    @media (max-width:400px){
+      .a2-drop__input{ flex:1 1 100%; }
+      .a2-drop__btn{ flex:1 1 100%; justify-content:center; }
+    }
+    @media (prefers-reduced-motion:reduce){
+      .a2-drop__glow, .a2-drop__sweep, .a2-drop__dot, .a2-drop__chip--mystery, .a2-drop__btn::after{ animation:none; }
+    }
+  </style>
+  <div class="a2-drop" data-a2-restock>
+    <div class="a2-drop__card">
+      <span class="a2-drop__glow" aria-hidden="true"></span>
+      <div class="a2-drop__chips" aria-hidden="true">
+        <span class="a2-drop__chip" style="--c:linear-gradient(150deg,#2A2C30,#0E0F11)"></span>
+        <span class="a2-drop__chip" style="--c:linear-gradient(150deg,#C9CDD2,#33363B)"></span>
+        <span class="a2-drop__chip" style="--c:linear-gradient(150deg,#3A6076,#1A3142)"></span>
+        <span class="a2-drop__chip" style="--c:linear-gradient(150deg,#E5322B,#A01913)"></span>
+        <span class="a2-drop__chip" style="--c:linear-gradient(150deg,#A6ACB1,#6C7176)"></span>
+        <span class="a2-drop__chip a2-drop__chip--mystery">?</span>
+        <span class="a2-drop__sweep"></span>
+      </div>
+
+      <p class="a2-drop__kicker"><span class="a2-drop__dot"></span>{{ _eyebrow }}</p>
+      <h2 class="a2-drop__title">{{ _heading }}</h2>
+      <p class="a2-drop__body">{{ _body }}</p>
+
+      <form class="a2-drop__form" data-a2-klaviyo-form
+            data-a2-company="YejYTH"
+            data-a2-list="TpVuRM"
+            data-a2-event="sp_restock_notify"
+            data-a2-source="SP Restock Alert (PDP) · {{ _p.title }}"
+            data-a2-props='{"SP Restock Interest":{{ _p.title | json }}}'
+            data-a2-success="You’re on the list — we’ll be in touch when the colors drop."
+            novalidate>
+        <fieldset class="a2-drop__sizes">
+          <legend class="a2-drop__sizeslabel">Your size <span>optional</span></legend>
+          {%- for s in _sizes -%}
+            {%- assign _sid = s | handleize -%}
+            <input class="a2-drop__sr a2-drop__sizeradio" type="radio" name="restock_size" id="a2sz-{{ _p.id }}-{{ _sid }}" value="{{ s | escape }}" data-a2-prop="SP Restock Size" />
+            <label class="a2-drop__sizepill" for="a2sz-{{ _p.id }}-{{ _sid }}">{{ s }}</label>
+          {%- endfor -%}
+        </fieldset>
+        <div class="a2-drop__field">
+          <label class="a2-drop__sr" for="a2-drop-email-{{ _p.id }}">Email address</label>
+          <input class="a2-drop__input" id="a2-drop-email-{{ _p.id }}" type="email" name="email"
+                 required autocomplete="email" inputmode="email" placeholder="you@email.com" />
+          <button class="a2-drop__btn" type="submit">
+            Notify me
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          </button>
+        </div>
+        <div class="a2-drop__hp" aria-hidden="true">
+          <label>Leave this field blank<input type="text" tabindex="-1" autocomplete="off" data-a2-hp /></label>
+        </div>
+        <p class="a2-drop__msg" data-a2-msg role="status" aria-live="polite"></p>
+      </form>
+      <p class="a2-drop__fine">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+        First look, no spam — one note the day they drop.
+      </p>
+    </div>
+  </div>
+  <script>
+  (function(){
+    // a2-lp.js already posts this form to Klaviyo + dataLayer. Here we ADD the
+    // A2 CRM identify with the exact scoreboard source string, so restock
+    // signups are attributed as "restock_alert".
+    var wrap = document.querySelector('[data-a2-restock]');
+    if (!wrap || wrap.__a2rsInit) return;
+    wrap.__a2rsInit = true;
+    var form = wrap.querySelector('form[data-a2-klaviyo-form]');
+    if (!form) return;
+    form.addEventListener('submit', function(){
+      var hp = form.querySelector('[data-a2-hp]');
+      if (hp && hp.value) return; // honeypot: bot, skip
+      var input = form.querySelector('input[type="email"]');
+      var email = (input && input.value || '').trim().toLowerCase();
+      if (!email || email.indexOf('@') < 1) return;
+      try { if (typeof window.a2_identify === 'function') window.a2_identify(email, 'restock_alert'); } catch(e){}
+      try { if (typeof window.a2IdentifyVisitor === 'function') window.a2IdentifyVisitor(email); } catch(e){}
+      try { sessionStorage.setItem('a2_visitor_email', email); } catch(e){}
+    }, false);
+  })();
+  </script>
+{%- endif -%}

--- a/shopify/snippets/a2-save-build.liquid
+++ b/shopify/snippets/a2-save-build.liquid
@@ -1,0 +1,209 @@
+{%- comment -%}
+  A2 Bikes — Play 3: "Save your build / email me this quote" (bike PDPs).
+  ---------------------------------------------------------------------------
+  Car-configurator move: the shopper emails their configured build + price to
+  themselves, which identifies them on every device they open it on.
+
+  Self-contained (a2-lp.js is NOT loaded on the PDP). Reads the live build from
+  window.A2_FIT_CTX (set by a2-fit-engine, always present on the bike PDP) plus
+  the live DOM: [data-price] (current price), the active .build-pill, and the
+  selected option buttons ([data-opt][aria-pressed="true"]).
+
+  Identity wiring:
+    - window.a2_identify(email, "save_build")   -> CRM scoreboard (mandatory)
+    - window.a2IdentifyVisitor(email)           -> existing Klaviyo/GA4 helper
+    - Klaviyo client subscription (custom_source "save_build") with the build in
+      profile properties, so a "Saved Build" flow can email the quote.
+    - dataLayer event "save_build_email_capture"
+
+  Params (all optional; passed from sppdp-product settings):
+    enabled        (bool)   render only when true
+    klaviyo_company(string) default "YejYTH"
+    klaviyo_list   (string) list the Saved-Build flow listens on (blank = CRM only)
+    button_label / heading / subtext / cta_label / success_text  (strings)
+{%- endcomment -%}
+
+{%- if enabled -%}
+{%- assign _kco = klaviyo_company | default: 'YejYTH' -%}
+<div class="a2sb" id="a2sb-{{ product.id }}"
+     data-a2sb
+     data-company="{{ _kco | escape }}"
+     data-list="{{ klaviyo_list | escape }}"
+     {% if customer %}data-logged-in="1"{% endif %}>
+  <button type="button" class="a2sb__open" data-a2sb-open aria-expanded="false" aria-controls="a2sb-panel-{{ product.id }}">
+    <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M4 4h12l4 4v12a0 0 0 0 1 0 0H4z M8 4v5h7 M8 20v-7h9"/></svg>
+    <span>{{ button_label | default: 'Save this build / email me the quote' }}</span>
+  </button>
+
+  <div class="a2sb__panel" id="a2sb-panel-{{ product.id }}" data-a2sb-panel hidden>
+    <div data-a2sb-step="capture">
+      <p class="a2sb__h">{{ heading | default: 'Email yourself this build' }}</p>
+      <p class="a2sb__sub">{{ subtext | default: 'We’ll send your spec + price so you can pick up on any device.' }}</p>
+      <p class="a2sb__quote" data-a2sb-quote></p>
+      <form class="a2sb__form" data-a2sb-form novalidate>
+        <label class="a2sb__sr" for="a2sb-email-{{ product.id }}">Email address</label>
+        <input id="a2sb-email-{{ product.id }}" class="a2sb__in" type="email" name="email" required
+               autocomplete="email" inputmode="email" placeholder="you@email.com">
+        <div class="a2sb__hp" aria-hidden="true"><label>Leave blank<input type="text" tabindex="-1" autocomplete="off" data-a2sb-hp></label></div>
+        <button class="a2sb__send" type="submit">{{ cta_label | default: 'Email my build' }}</button>
+        <p class="a2sb__msg" data-a2sb-msg role="status" aria-live="polite"></p>
+      </form>
+    </div>
+    <div data-a2sb-step="done" hidden>
+      <p class="a2sb__h">{{ success_text | default: 'Saved — check your inbox for your build and price.' }}</p>
+    </div>
+  </div>
+</div>
+
+{%- style -%}
+  #a2sb-{{ product.id }}.a2sb{margin-top:10px;}
+  #a2sb-{{ product.id }} .a2sb__open{display:inline-flex;align-items:center;gap:8px;width:100%;justify-content:center;
+    padding:12px 16px;font-size:14px;font-weight:600;cursor:pointer;background:transparent;
+    border:1px solid currentColor;border-radius:10px;color:inherit;opacity:.9;}
+  #a2sb-{{ product.id }} .a2sb__open:hover{opacity:1;}
+  #a2sb-{{ product.id }} .a2sb__open svg{flex:0 0 auto;}
+  #a2sb-{{ product.id }} .a2sb__panel{margin-top:10px;padding:14px;border:1px solid rgba(0,0,0,.14);border-radius:10px;}
+  #a2sb-{{ product.id }} .a2sb__h{margin:0 0 4px;font-size:15px;font-weight:700;}
+  #a2sb-{{ product.id }} .a2sb__sub{margin:0 0 8px;font-size:13px;opacity:.8;line-height:1.4;}
+  #a2sb-{{ product.id }} .a2sb__quote{margin:0 0 10px;font-size:12.5px;opacity:.85;line-height:1.45;}
+  #a2sb-{{ product.id }} .a2sb__quote:empty{display:none;}
+  #a2sb-{{ product.id }} .a2sb__form{display:flex;flex-direction:column;gap:8px;}
+  #a2sb-{{ product.id }} .a2sb__in{width:100%;padding:12px 14px;font-size:16px;border:1px solid rgba(0,0,0,.25);
+    border-radius:8px;background:#fff;color:#111;box-sizing:border-box;}
+  #a2sb-{{ product.id }} .a2sb__send{width:100%;padding:12px 16px;font-size:15px;font-weight:700;border:0;
+    border-radius:8px;cursor:pointer;background:#111;color:#fff;}
+  #a2sb-{{ product.id }} .a2sb__send:hover{opacity:.92;}
+  #a2sb-{{ product.id }} .a2sb__msg{margin:2px 0 0;font-size:13px;min-height:1em;}
+  #a2sb-{{ product.id }} .a2sb__msg[data-state="error"]{color:#c0392b;}
+  #a2sb-{{ product.id }} .a2sb__hp{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;}
+  #a2sb-{{ product.id }} .a2sb__sr{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);}
+{%- endstyle -%}
+
+<script>
+(function(){
+  var root = document.getElementById("a2sb-{{ product.id }}");
+  if (!root || root.__a2sbInit) return;
+  root.__a2sbInit = true;
+
+  var openBtn = root.querySelector("[data-a2sb-open]");
+  var panel   = root.querySelector("[data-a2sb-panel]");
+  var form    = root.querySelector("[data-a2sb-form]");
+  var msgBox  = root.querySelector("[data-a2sb-msg]");
+  var quoteEl = root.querySelector("[data-a2sb-quote]");
+  var stepCap = root.querySelector('[data-a2sb-step="capture"]');
+  var stepDone= root.querySelector('[data-a2sb-step="done"]');
+
+  function ctx(){ return window.A2_FIT_CTX || {}; }
+
+  // Build a human-readable summary of the CURRENT configuration from live DOM.
+  function currentBuild(){
+    var c = ctx();
+    var out = { title: c.productTitle || document.title, url: c.url || location.pathname,
+                model: c.model || "", build: c.build || "" };
+    // Active build pill (groupset).
+    var pill = document.querySelector(".build-pill.is-active");
+    out.buildLabel = pill ? (pill.textContent || "").trim() : "";
+    // Selected variant options (Color / Size / Wheelset).
+    var opts = [];
+    document.querySelectorAll('[data-opt][aria-pressed="true"]').forEach(function(b){
+      var v = b.getAttribute("data-value"); if (v) opts.push(v);
+    });
+    out.options = opts;
+    // Live price from the buy box.
+    var priceEl = document.querySelector("[data-price]");
+    out.price = priceEl ? (priceEl.textContent || "").trim() : (c.price || "");
+    // Selected variant id (if present).
+    var vid = document.querySelector("[data-variant-id]");
+    out.variantId = vid ? vid.value : "";
+    return out;
+  }
+
+  function quoteText(b){
+    var bits = [];
+    if (b.title) bits.push(b.title);
+    if (b.buildLabel) bits.push(b.buildLabel);
+    if (b.options && b.options.length) bits.push(b.options.join(" · "));
+    if (b.price) bits.push(b.price);
+    return bits.join("  ·  ");
+  }
+
+  function pushDL(evt, extra){
+    if (typeof window.a2dl === "function") { window.a2dl(evt, extra || {}); return; }
+    window.dataLayer = window.dataLayer || [];
+    var p = { event: evt }; if (extra) Object.keys(extra).forEach(function(k){ p[k]=extra[k]; });
+    window.dataLayer.push(p);
+  }
+
+  openBtn.addEventListener("click", function(){
+    var open = !panel.hidden;
+    if (open) { panel.hidden = true; openBtn.setAttribute("aria-expanded","false"); return; }
+    panel.hidden = false;
+    openBtn.setAttribute("aria-expanded","true");
+    if (quoteEl) quoteEl.textContent = quoteText(currentBuild());
+    pushDL("save_build_open", { source: "save_build" });
+    var input = form && form.querySelector('input[type="email"]');
+    if (input) input.focus();
+  });
+
+  function setMsg(state, text){ if (msgBox){ msgBox.setAttribute("data-state", state); msgBox.textContent = text; } }
+
+  function subscribeKlaviyo(email, b){
+    var company = root.getAttribute("data-company"), list = root.getAttribute("data-list");
+    if (!company || !list) return; // CRM identify still fires without this
+    var body = { data: { type: "subscription", attributes: {
+      custom_source: "save_build",
+      profile: { data: { type: "profile", attributes: { email: email, properties: {
+        a2_capture_source: "save_build",
+        bike_model: b.model, build: b.build, build_label: b.buildLabel,
+        selected_options: (b.options||[]).join(", "), price: b.price,
+        variant_id: b.variantId, product_title: b.title, product_url: b.url
+      } } } }
+    }, relationships: { list: { data: { type: "list", id: list } } } } };
+    try {
+      fetch("https://a.klaviyo.com/client/subscriptions/?company_id=" + encodeURIComponent(company), {
+        method: "POST", headers: { "Content-Type": "application/json", revision: "2024-10-15" },
+        body: JSON.stringify(body)
+      }).catch(function(){});
+    } catch(e){}
+    // Also fire a Klaviyo event the flow can trigger on, if Klaviyo is on-page.
+    try {
+      if (window.klaviyo && typeof window.klaviyo.track === "function") {
+        var _t = function(){ try { window.klaviyo.track("Saved Build", {
+          bike_model: b.model, build: b.build, build_label: b.buildLabel,
+          selected_options: (b.options||[]).join(", "), price: b.price, url: b.url, product_title: b.title
+        }); } catch(e){} };
+        var id = window.klaviyo.identify({ email: email });
+        (id && typeof id.then === "function") ? id.then(_t, _t) : _t();
+      } else if (window._learnq) {
+        window._learnq.push(["identify", { "$email": email }]);
+        window._learnq.push(["track", "Saved Build", { bike_model: b.model, build: b.build, price: b.price, url: b.url }]);
+      }
+    } catch(e){}
+  }
+
+  function identify(email, b){
+    try { if (typeof window.a2_identify === "function") window.a2_identify(email, "save_build"); } catch(e){}
+    try { if (typeof window.a2IdentifyVisitor === "function") window.a2IdentifyVisitor(email); } catch(e){}
+    try { sessionStorage.setItem("a2_visitor_email", email); } catch(e){}
+    subscribeKlaviyo(email, b);
+  }
+
+  form.addEventListener("submit", function(e){
+    e.preventDefault();
+    var hp = form.querySelector("[data-a2sb-hp]");
+    if (hp && hp.value) { showDone(); return; } // silent bot pass
+    var input = form.querySelector('input[type="email"]');
+    var email = (input && input.value || "").trim().toLowerCase();
+    if (!email || email.indexOf("@") < 1) { setMsg("error", "Please enter a valid email address."); return; }
+    setMsg("ok", "Sending…");
+    var b = currentBuild();
+    identify(email, b);
+    pushDL("save_build_email_capture", { source: "save_build", bike_model: b.model,
+      build: b.build, price: b.price, email_domain: email.split("@")[1] || null });
+    showDone();
+  });
+
+  function showDone(){ if (stepCap) stepCap.hidden = true; if (stepDone) stepDone.hidden = false; }
+})();
+</script>
+{%- endif -%}

--- a/shopify/templates/index.json
+++ b/shopify/templates/index.json
@@ -1,0 +1,455 @@
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "sections": {
+    "hero": {
+      "type": "wa-hero",
+      "settings": {
+        "hero_image": "shopify://shop_images/Screenshot_2025-04-08_at_11.56.13_AM.png",
+        "hero_image_mobile": "shopify://shop_images/Slow_Motion.00_02_17_19.Still001_1_6.jpg",
+        "hero_eyebrow": "Rider Focused. Always.",
+        "hero_heading": "Pro-level bikes. Without the pro-level price.",
+        "hero_sub": "Designed by one of the sport's most respected triathlon-bike engineers — sold direct from Oregon, so you skip the retail markup.",
+        "hero_cta1_label": "Shop the SP",
+        "hero_cta1_link": "shopify://products/sp-sram-rival-1",
+        "hero_cta2_label": "Find your bike in 60 seconds",
+        "hero_cta2_link": "/pages/a2-bikes-selector-quiz",
+        "hero_cta2_modal": false
+      }
+    },
+    "trust_ticker": {
+      "type": "scrolling-content",
+      "blocks": {
+        "text-1": {
+          "type": "text",
+          "settings": {
+            "text": "Flexible Sizing",
+            "link": "/pages/sp-performance#a2-fit-calc"
+          }
+        },
+        "text_ykKpRV": {
+          "type": "text",
+          "settings": {
+            "text": "Crash Replacement Program",
+            "link": "/pages/crash-replacement-policy"
+          }
+        },
+        "text-2": {
+          "type": "text",
+          "settings": {
+            "text": "Perfect Fit Promise",
+            "link": "/pages/sp-performance#a2-fit-calc"
+          }
+        },
+        "text-3": {
+          "type": "text",
+          "settings": {
+            "text": "Free 30-Day Returns",
+            "link": "/pages/a2-promise"
+          }
+        },
+        "text_6C6q47": {
+          "type": "text",
+          "settings": {
+            "text": "Fast, Reliable Shipping",
+            "link": ""
+          }
+        },
+        "text_3hf7kx": {
+          "type": "text",
+          "settings": {
+            "text": "Lifetime Warranty",
+            "link": "/pages/warranty"
+          }
+        }
+      },
+      "block_order": [
+        "text-1",
+        "text_ykKpRV",
+        "text-2",
+        "text-3",
+        "text_6C6q47",
+        "text_3hf7kx"
+      ],
+      "settings": {
+        "font_choice": "ff-heading",
+        "text_font_class": "fs-body-300",
+        "duration": 10,
+        "direction": "reverse",
+        "gap": 100,
+        "padding_top": 22,
+        "padding_bottom": 22,
+        "borders": "top-bottom",
+        "background_color": "#242526",
+        "text_color": "#faf7c3",
+        "border_color": "#242526",
+        "enable_animation": true,
+        "divider_style": "none",
+        "section_padding": "section--vertical-padding-bottom-only"
+      }
+    },
+    "credibility": {
+      "type": "wa-credibility",
+      "blocks": {
+        "c1": {
+          "type": "proof",
+          "settings": {
+            "title": "Designed by engineer Kevin Quan",
+            "body": "A2's geometry comes from Kevin Quan, a designer behind some of the most successful triathlon bikes ever made.",
+            "show_stars": false
+          }
+        },
+        "c2": {
+          "type": "proof",
+          "settings": {
+            "title": "Trusted at the Ironman World Championships",
+            "body": "A2 bikes have been raced on the lava fields of Kona — the toughest proving ground in the sport.",
+            "show_stars": false
+          }
+        },
+        "c3": {
+          "type": "proof",
+          "settings": {
+            "title": "Best Beginner Triathlon Bike",
+            "body": "Named by Triathlete Magazine — a five-time winner of the category.",
+            "show_stars": true
+          }
+        }
+      },
+      "block_order": [
+        "c1",
+        "c2",
+        "c3"
+      ],
+      "settings": {
+        "cred_image": "shopify://shop_images/image2_1.jpg",
+        "eyebrow": "Proven, not promised",
+        "heading": "Designed by Kevin Quan. Tested at Kona."
+      }
+    },
+    "lineup": {
+      "type": "wa-products",
+      "blocks": {
+        "sp": {
+          "type": "product",
+          "settings": {
+            "image": "shopify://shop_images/DSCF9203-Edit.jpg",
+            "badge": "Triathlon",
+            "name": "SP",
+            "product": "sp-shimano-105n",
+            "price": "$3,115",
+            "body": "Our triathlon and time-trial machine — superbike aerodynamics and fit, without the superbike price.",
+            "link": "/pages/sp-performance"
+          }
+        },
+        "rogue": {
+          "type": "product",
+          "settings": {
+            "image": "shopify://shop_images/P1011937-Edit.jpg",
+            "badge": "Road",
+            "name": "Rogue",
+            "product": "rogue-shimano-105",
+            "price": "$2,699",
+            "body": "One road bike for everything — light, fast and ready for any route.",
+            "link": "/pages/rogue-road"
+          }
+        }
+      },
+      "block_order": [
+        "sp",
+        "rogue"
+      ],
+      "settings": {
+        "eyebrow": "The lineup",
+        "heading": "Find your A2",
+        "lede": "Two platforms, one obsession: fast bikes that fit real riders — priced direct.",
+        "show_financing_line": true,
+        "affirm_public_key": "WSAUD4RQEGCMBW2I",
+        "financing_suffix": "Also HSA/FSA eligible"
+      }
+    },
+    "quiz_band": {
+      "type": "a2-quiz-cta",
+      "settings": {
+        "enable": true,
+        "style": "band"
+      }
+    },
+    "financing_band": {
+      "type": "a2-collection-financing-band",
+      "settings": {
+        "compact": false,
+        "affirm_logo": "shopify://shop_images/986051c-affirm-logo.png",
+        "heading": "Buy now, pay later with Affirm.",
+        "text": "<p>Choose Affirm at checkout to split your purchase into monthly payments.</p>",
+        "show_as_low_as": true,
+        "secondary_text": "<p>Prefer pre-tax dollars? Eligible riders save an average of 30% with HSA/FSA via Truemed.</p>",
+        "disclosure": "Payment options through Affirm are subject to eligibility, may not be available in all states, and are provided by these lending partners:",
+        "button_label": "Explore financing options",
+        "button_link": "",
+        "affirm_public_key": "",
+        "bg_color": "#f7f7e8",
+        "text_color": "#222425",
+        "accent_color": "#c51c26"
+      }
+    },
+    "quote": {
+      "type": "quote",
+      "blocks": {
+        "quote-1": {
+          "type": "quote",
+          "settings": {
+            "logo": "shopify://shop_images/Esquire_logo.png",
+            "quote": "<p>\"This bike is fast. Like, freakishly fast. Like, Sonic-on-performance-enhancing-drugs fast. It also looks cool as hell.\" - Esquire Magazine</p>",
+            "title": "",
+            "quote_tag": "h4",
+            "font_size": "small"
+          }
+        },
+        "quote-2": {
+          "type": "quote",
+          "settings": {
+            "logo": "shopify://shop_images/Triathlete_logo_650x185_eb6de153-efa7-4e68-8b18-a73c600dcf1a.png",
+            "quote": "<p>\"A2 did a great job of offering four sizes with a fairly wide range of reach, made even more adaptable with intentional adjustability. In particular, the front-end of the new SP1.X series has a stem that allows for more flexibility than the last version, and the seatpost head has a huge range of fore/aft adjustability, allowing for a very steep or shallow effective seat angles and potential fit setups.\" - Triathlete Magazine</p>",
+            "title": "",
+            "quote_tag": "h5",
+            "font_size": "small"
+          }
+        }
+      },
+      "block_order": [
+        "quote-1",
+        "quote-2"
+      ],
+      "settings": {
+        "autoplay_enabled": true,
+        "autoplay_delay": 5,
+        "pagination_style": "logos",
+        "font_choice": "heading",
+        "enable_animation": true,
+        "divider_style": "none",
+        "section_padding": "section--vertical-padding-top-bottom"
+      }
+    },
+    "image_hero-1": {
+      "type": "image-hero",
+      "blocks": {
+        "accent": {
+          "type": "accent",
+          "disabled": true,
+          "settings": {
+            "accent": "NEW"
+          }
+        },
+        "heading": {
+          "type": "heading",
+          "settings": {
+            "title": "Adjustability = Speed",
+            "heading_tag": "h2",
+            "heading_font_class": "fs-heading-display-1"
+          }
+        },
+        "text": {
+          "type": "text",
+          "settings": {
+            "text": "<p>It doesn't matter how aero your bike is, if you aren't comfortable enough to hold your aero position, you'll be slower. The SP is the most adjustable Tri Bike in the world, to get you comfortable, and get you fast.</p>",
+            "text_font_class": "fs-body-100"
+          }
+        }
+      },
+      "block_order": [
+        "accent",
+        "heading",
+        "text"
+      ],
+      "settings": {
+        "image_aspect": "custom",
+        "desktop_height": 90,
+        "mobile_height": 100,
+        "image": "shopify://shop_images/2022-03-18_A2_Bikes_0568_4d7795f5-c465-4699-bec4-2eb7d675d4a3.jpg",
+        "focal_point": "image_presentation",
+        "mobile_focal_point": "image_presentation",
+        "media_link": "/pages/sp-performance",
+        "text_position": "center_flex-start",
+        "text_position_mobile": "center_center",
+        "text_color": "#ffffff",
+        "button_background_color": "#ffffff",
+        "button_text_color": "#000000",
+        "color_overlay": "#000000",
+        "color_overlay_gradient": "linear-gradient(180deg, rgba(0, 0, 0, 1), rgba(9, 9, 9, 0.52) 49%, rgba(0, 0, 0, 0.35) 100%)",
+        "overlay_opacity": 61,
+        "enable_animation": true,
+        "section_padding": "section--vertical-padding-none"
+      }
+    },
+    "promise": {
+      "type": "wa-promise",
+      "blocks": {
+        "m1": {
+          "type": "card",
+          "settings": {
+            "phrase": "retail markup",
+            "title": "Sold direct, priced honestly",
+            "body": "Big brands build dealer margin and retail markup into the price. We don't. You pay for engineering and materials — nothing else.",
+            "tag": "Direct-to-rider"
+          }
+        },
+        "m2": {
+          "type": "card",
+          "settings": {
+            "phrase": "dealer middleman",
+            "title": "Ships from Oregon, set up at home",
+            "body": "No showroom upsell. Your bike ships from our Oregon shop, ready to finish assembly at home with our step-by-step guides.",
+            "tag": "Pacific Northwest built"
+          }
+        },
+        "m3": {
+          "type": "card",
+          "settings": {
+            "phrase": "annual obsolescence",
+            "title": "Lifetime warranty, free size exchanges",
+            "body": "We don't chase yearly model cycles. Your A2 is backed by a lifetime frame warranty and free size exchanges if the fit isn't right.",
+            "tag": "Backed for life"
+          }
+        }
+      },
+      "block_order": [
+        "m1",
+        "m2",
+        "m3"
+      ],
+      "settings": {
+        "eyebrow": "The A2 promise",
+        "heading": "What you don't pay for",
+        "lede": "A2 sells direct. That means your money goes into the bike — not the markup, the middleman, or next year's upgrade."
+      }
+    },
+    "support": {
+      "type": "image-with-text",
+      "blocks": {
+        "heading_n7mW4a": {
+          "type": "heading",
+          "settings": {
+            "title": "A2 Support",
+            "heading_tag": "h2",
+            "heading_font_class": "fs-heading-display-3"
+          }
+        },
+        "subheading_MDJyGq": {
+          "type": "subheading",
+          "settings": {
+            "subheading": "At A2, we take pride in unmatched customer service. As triathletes and cyclists ourselves, we’re here to help you reach your goals. Whether you web chat, email, or text us, you’ll hear back within hours. From pre-purchase questions to post-ride support, we’ve always got your back.",
+            "subheading_tag": "h2",
+            "subheading_font_class": "fs-heading-6-base"
+          }
+        },
+        "button_bdhmwH": {
+          "type": "button",
+          "settings": {
+            "link": "shopify://pages/a2-promise",
+            "link_text": "Read More About Our Promise",
+            "button_style": "btn--primary"
+          }
+        }
+      },
+      "block_order": [
+        "heading_n7mW4a",
+        "subheading_MDJyGq",
+        "button_bdhmwH"
+      ],
+      "name": "t:sections.image_with_text.presets.name",
+      "settings": {
+        "image_position": "right",
+        "image": "shopify://shop_images/DSCF3143.jpg",
+        "aspect_ratio": "square",
+        "focal_point": "image_presentation",
+        "image_caption": "",
+        "text_alignment": "center",
+        "show_small_image": false,
+        "image_small_aspect": "square",
+        "image_small_focal_point": "image_presentation",
+        "background_color": "",
+        "text_color": "#000000",
+        "button_background_color": "#000000",
+        "button_text_color": "#ffffff",
+        "enable_animation": true,
+        "divider_style": "none",
+        "section_padding": "section--vertical-padding-top-bottom"
+      }
+    },
+    "news": {
+      "type": "blog-posts",
+      "blocks": {
+        "article-1": {
+          "type": "article",
+          "settings": {
+            "article": ""
+          }
+        },
+        "article-2": {
+          "type": "article",
+          "settings": {
+            "article": ""
+          }
+        }
+      },
+      "block_order": [
+        "article-1",
+        "article-2"
+      ],
+      "settings": {
+        "heading": "A2 Bikes in the News",
+        "heading_tag": "h2",
+        "subheading": "",
+        "link": "",
+        "link_text": "View all posts",
+        "button_style": "btn--callout",
+        "display_type": "all",
+        "blog": "news",
+        "max_articles": 2,
+        "show_tags": true,
+        "show_author": false,
+        "show_date": true,
+        "show_excerpt": true,
+        "show_featured_image": true,
+        "aspect_ratio": "square",
+        "enable_animation": true,
+        "divider_style": "solid",
+        "section_padding": "section--vertical-padding-top-bottom"
+      }
+    },
+    "capture": {
+      "type": "wa-capture",
+      "disabled": true,
+      "settings": {
+        "eyebrow": "Free sizing guide",
+        "heading": "Sizing a triathlon bike is harder than it should be.",
+        "sub": "Get our free guide and we'll help you dial in the right frame size, fit, and setup — before you ever click buy.",
+        "klaviyo_form_id": "WDFJLq",
+        "klaviyo_company_id": "YejYTH",
+        "trust": "No spam. Unsubscribe anytime."
+      }
+    }
+  },
+  "order": [
+    "hero",
+    "trust_ticker",
+    "credibility",
+    "lineup",
+    "quiz_band",
+    "financing_band",
+    "quote",
+    "image_hero-1",
+    "promise",
+    "support",
+    "news",
+    "capture"
+  ]
+}


### PR DESCRIPTION
Visitor-identification capture build-out — **all 9 plays addressed**. Each is built in the repo (`shopify/`), staged to a **draft** theme, and wired to the CRM contract `window.a2_identify(email, source)`. Nothing published. All theme writes used the staged-upload pipeline with `checksumMd5` verified byte-identical to local md5.

**Shared staged draft theme:** `176605397156` — duplicate of the 07‑18 live theme; holds Plays 1–8. Preview: `https://a2bikes.com/?preview_theme_id=176605397156`

---

| # | Play | Source | What shipped |
|---|------|--------|--------------|
| 1 | Exit-intent capture | `exit_intent` | `sections/a2-exit-intent.liquid` + `overlay-group.json` (ships disabled, blank offer) |
| 2 | Fit Calculator soft gate | `fit_calculator` | `snippets/a2-fit-engine.liquid` — identify + blur-lock breakdown |
| 3 | Save your build (PDP) | `save_build` | `snippets/a2-save-build.liquid` + `sppdp-product.liquid` |
| 4 | Email flows as identity | `newsletter`/`klaviyo_form`/`contact` | `theme.liquid` + `assets/a2-lp.js` capture handlers |
| 5 | Push the Octane quiz | `quiz` | `sections/a2-quiz-cta.liquid` + homepage + completion wiring |
| 6 | Back-in-stock alert | `restock_alert` | `snippets/a2-restock-alert.liquid` |
| 7 | Sign in with Shop | `account` | `theme.liquid` logged-in-customer wiring |
| 8 | Zoho chat asks email | `chat` | `theme.liquid` SalesIQ capture callbacks |
| 9 | Financing prequal | (Affirm-native) | **assessed — already compliant in theme; no new code** |

**Play 9 note:** the PDP already renders Affirm's own `.affirm-as-low-as` component (compliant "As low as $X/mo · See if you qualify" + TILA disclosures + Affirm modal). Per Affirm policy a bespoke payment calculator would be non-compliant, so no new code is the correct outcome; the `monthly=price÷months` var is dead code (never displayed). Activation is an owner toggle (`show_affirm_line` vs. Affirm app block) + Affirm Merchant Care review. Prequal runs in Affirm's UI so it has negligible CRM-identity value.

## Owner checklist before publishing
1. **P1:** discount amount + code, Klaviyo list id, copy → Enable. 2. **P3:** Klaviyo "Saved Build" flow + `sb_klaviyo_list`. 3. **P4:** Klaviyo flow coordination. 4. **P5:** confirm quiz destination (Octane embed has blank quiz id). 5. **P6:** set `custom.restock_alert` metafield. 6. **P7:** enable Sign in with Shop in admin. 7. **P8:** Zoho pre-chat email field + webhook. 8. **P9:** built-in Affirm line vs app block + Affirm review. 9. **Publish** (owner only) after re-syncing the draft to current live.

See `docs/A2-VISITOR-ID-BUILD.md` for verified theme IDs, per-play detail, CRM wiring, and checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Q8vJKD6PF8u3PRddHhYLw